### PR TITLE
Changed auth flow for Reddit authorization

### DIFF
--- a/src/main/java/ca/tunestumbler/api/io/entity/AuthValidationEntity.java
+++ b/src/main/java/ca/tunestumbler/api/io/entity/AuthValidationEntity.java
@@ -32,6 +32,9 @@ public class AuthValidationEntity implements Serializable {
 	@Column()
 	private String userId;
 
+	@Column(length = 350, unique = true)
+	private String authorizationUrl;
+
 	public String getStateId() {
 		return stateId;
 	}
@@ -78,6 +81,14 @@ public class AuthValidationEntity implements Serializable {
 
 	public void setUserId(String userId) {
 		this.userId = userId;
+	}
+
+	public String getAuthorizationUrl() {
+		return authorizationUrl;
+	}
+
+	public void setAuthorizationUrl(String authorizationUrl) {
+		this.authorizationUrl = authorizationUrl;
 	}
 
 }

--- a/src/main/java/ca/tunestumbler/api/io/entity/UserEntity.java
+++ b/src/main/java/ca/tunestumbler/api/io/entity/UserEntity.java
@@ -37,6 +37,9 @@ public class UserEntity implements Serializable {
 	@Column(nullable = true, unique = true)
 	private String refreshToken;
 
+	@Column(nullable = true)
+	private String tokenLifetime;
+
 	@Column(nullable = false)
 	private String lastModified;
 
@@ -120,6 +123,14 @@ public class UserEntity implements Serializable {
 
 	public void setRefreshToken(String refreshToken) {
 		this.refreshToken = refreshToken;
+	}
+
+	public String getTokenLifetime() {
+		return tokenLifetime;
+	}
+
+	public void setTokenLifetime(String tokenLifetime) {
+		this.tokenLifetime = tokenLifetime;
 	}
 
 	public String getLastModified() {

--- a/src/main/java/ca/tunestumbler/api/security/AuthenticationFilter.java
+++ b/src/main/java/ca/tunestumbler/api/security/AuthenticationFilter.java
@@ -55,7 +55,10 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 		UserService userService = (UserService) SpringApplicationContext.getBean("userServiceImpl");
 		UserDTO userDTO = userService.getUser(userName);
 
-		res.addHeader(SecurityConstants.HEADER_STRING, SecurityConstants.TOKEN_PREFIX + token);
-		res.addHeader("UserID", userDTO.getUserId());
+		res.setHeader("Access-Control-Expose-Headers", SecurityConstants.AUTH_HEADER_STRING + ", " 
+				+ SecurityConstants.USERID_HEADER_STRING + ", " + SecurityConstants.LIFETIME_HEADER_STRING);
+		res.addHeader(SecurityConstants.AUTH_HEADER_STRING, SecurityConstants.TOKEN_PREFIX + token);
+		res.addHeader(SecurityConstants.USERID_HEADER_STRING, userDTO.getUserId());
+		res.addHeader(SecurityConstants.LIFETIME_HEADER_STRING, Long.toString(SecurityConstants.EXPIRATION_TIME));
 	}
 }

--- a/src/main/java/ca/tunestumbler/api/security/AuthorizationFilter.java
+++ b/src/main/java/ca/tunestumbler/api/security/AuthorizationFilter.java
@@ -24,7 +24,7 @@ public class AuthorizationFilter extends BasicAuthenticationFilter {
 	@Override
 	protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
 			throws IOException, ServletException {
-		String header = req.getHeader(SecurityConstants.HEADER_STRING);
+		String header = req.getHeader(SecurityConstants.AUTH_HEADER_STRING);
 
 		if (header == null || !header.startsWith(SecurityConstants.TOKEN_PREFIX)) {
 			chain.doFilter(req, res);
@@ -37,7 +37,7 @@ public class AuthorizationFilter extends BasicAuthenticationFilter {
 	}
 
 	private UsernamePasswordAuthenticationToken getAuthentication(HttpServletRequest request) {
-		String token = request.getHeader(SecurityConstants.HEADER_STRING);
+		String token = request.getHeader(SecurityConstants.AUTH_HEADER_STRING);
 
 		if (token != null) {
 			token = token.replace(SecurityConstants.TOKEN_PREFIX, "");

--- a/src/main/java/ca/tunestumbler/api/security/SecurityConstants.java
+++ b/src/main/java/ca/tunestumbler/api/security/SecurityConstants.java
@@ -3,9 +3,11 @@ package ca.tunestumbler.api.security;
 import ca.tunestumbler.api.SpringApplicationContext;
 
 public class SecurityConstants {
-	public static final long EXPIRATION_TIME = 31556952000L; // 1 year
+	public static final long EXPIRATION_TIME = 1814400000L; // 3 weeks
 	public static final String TOKEN_PREFIX = "Bearer ";
-	public static final String HEADER_STRING = "Authorization";
+	public static final String AUTH_HEADER_STRING = "Authorization";
+	public static final String USERID_HEADER_STRING = "UserID";
+	public static final String LIFETIME_HEADER_STRING = "Lifetime";
 	public static final String SIGN_UP_URL = "/users";
 	public static final String HANDLER_URL = "/auth/handler";
 

--- a/src/main/java/ca/tunestumbler/api/service/impl/AuthValidationServiceImpl.java
+++ b/src/main/java/ca/tunestumbler/api/service/impl/AuthValidationServiceImpl.java
@@ -39,12 +39,22 @@ public class AuthValidationServiceImpl implements AuthValidationService {
 		}
 
 		String stateId = sharedUtils.generateStateId(50);
+//		for testing, redirect_uri=http://localhost:3000/
+		String authorizationUrl = "https://www.reddit.com/api/v1/authorize" +
+				"?client_id=VvztT4RO6UUmAA" +
+				"&response_type=code" +
+				"&state=" + stateId +
+				"&redirect_uri=https://tunestumbler.ca/" +
+				"&duration=permanent" +
+				"&scope=read,history,vote,save,account,subscribe,mysubreddits";
+		
 		AuthValidationEntity authValidationEntity = new AuthValidationEntity();
 
 		authValidationEntity.setUserEntity(userEntity);
 		authValidationEntity.setStateId(stateId);
 		authValidationEntity.setUserId(userEntity.getUserId());
 		authValidationEntity.setLastModified(sharedUtils.getCurrentTime());
+		authValidationEntity.setAuthorizationUrl(authorizationUrl);
 
 		AuthValidationEntity storedAuthValidation = authValidationRepository.save(authValidationEntity);
 

--- a/src/main/java/ca/tunestumbler/api/service/impl/UserServiceImpl.java
+++ b/src/main/java/ca/tunestumbler/api/service/impl/UserServiceImpl.java
@@ -140,7 +140,8 @@ public class UserServiceImpl implements UserService {
 		}
 
 		userEntity.setToken(null);
-		userEntity.setRefreshToken(null);		
+		userEntity.setRefreshToken(null);
+		userEntity.setTokenLifetime(null);
 		userRepository.save(userEntity);
 	}
 	

--- a/src/main/java/ca/tunestumbler/api/shared/dto/AuthValidationDTO.java
+++ b/src/main/java/ca/tunestumbler/api/shared/dto/AuthValidationDTO.java
@@ -10,6 +10,7 @@ public class AuthValidationDTO implements Serializable {
 	private String lastModified;
 	private UserDTO userDTO;
 	private String userId;
+	private String authorizationUrl;
 
 	public String getStateId() {
 		return stateId;
@@ -57,6 +58,14 @@ public class AuthValidationDTO implements Serializable {
 
 	public void setUserId(String userId) {
 		this.userId = userId;
+	}
+
+	public String getAuthorizationUrl() {
+		return authorizationUrl;
+	}
+
+	public void setAuthorizationUrl(String authorizationUrl) {
+		this.authorizationUrl = authorizationUrl;
 	}
 
 }

--- a/src/main/java/ca/tunestumbler/api/shared/dto/UserDTO.java
+++ b/src/main/java/ca/tunestumbler/api/shared/dto/UserDTO.java
@@ -14,6 +14,7 @@ public class UserDTO implements Serializable {
 	private String redditAccountName;
 	private String token;
 	private String refreshToken;
+	private String tokenLifetime;
 	private String lastModified;
 	private List<AuthValidationDTO> validation;
 	private List<SubredditDTO> subreddit;
@@ -92,6 +93,14 @@ public class UserDTO implements Serializable {
 
 	public void setRefreshToken(String refreshToken) {
 		this.refreshToken = refreshToken;
+	}
+
+	public String getTokenLifetime() {
+		return tokenLifetime;
+	}
+
+	public void setTokenLifetime(String tokenLifetime) {
+		this.tokenLifetime = tokenLifetime;
 	}
 
 	public String getLastModified() {

--- a/src/main/java/ca/tunestumbler/api/ui/model/request/UserDetailsRequestModel.java
+++ b/src/main/java/ca/tunestumbler/api/ui/model/request/UserDetailsRequestModel.java
@@ -10,7 +10,7 @@ public class UserDetailsRequestModel {
 	private String email;
 
 	@NotNull(message = "Password cannot be null")
-	@Size(min = 1, max = 30, message = "Password must have length of 1-30 characters")
+	@Size(min = 8, max = 30, message = "Password must have length of 8-30 characters")
 	private String password;
 
 	public String getEmail() {

--- a/src/main/java/ca/tunestumbler/api/ui/model/response/auth/AuthConnectResponseModel.java
+++ b/src/main/java/ca/tunestumbler/api/ui/model/response/auth/AuthConnectResponseModel.java
@@ -1,0 +1,14 @@
+package ca.tunestumbler.api.ui.model.response.auth;
+
+public class AuthConnectResponseModel {
+	private String authorizationUrl;
+
+	public String getAuthorizationUrl() {
+		return authorizationUrl;
+	}
+
+	public void setAuthorizationUrl(String authorizationUrl) {
+		this.authorizationUrl = authorizationUrl;
+	}
+
+}

--- a/src/main/java/ca/tunestumbler/api/ui/model/response/auth/AuthResponseModel.java
+++ b/src/main/java/ca/tunestumbler/api/ui/model/response/auth/AuthResponseModel.java
@@ -1,8 +1,9 @@
-package ca.tunestumbler.api.ui.model.response;
+package ca.tunestumbler.api.ui.model.response.auth;
 
 public class AuthResponseModel {
 	private String access_token;
 	private String refresh_token;
+	private int expires_in;
 	private String scope;
 
 	public String getAccess_token() {
@@ -19,6 +20,14 @@ public class AuthResponseModel {
 
 	public void setRefresh_token(String refresh_token) {
 		this.refresh_token = refresh_token;
+	}
+
+	public int getExpires_in() {
+		return expires_in;
+	}
+
+	public void setExpires_in(int expires_in) {
+		this.expires_in = expires_in;
 	}
 
 	public String getScope() {


### PR DESCRIPTION
- Since the Tunestumbler API cannot redirect the Tunestumbler website
to an external url, the API needs to return the authorization url
itself, that is generated server side, to the client. Then the client
will send the state and code to the API, which the API will use to
generate a Reddit authentication token. This token will be saved to
the user’s data in the database, and then the user will be able to
make Reddit requests just with the Tunestumbler token.
- Generate authorization url to send to the client to allow them to
authenticate with Reddit
- Expose Tunestumbler and Reddit authentication tokens and token
lifetimes in response header so that the client can easily use and
store them
- Expose userId in response header
- Save reddit token lifetime to user data and expose this in response
header so that the client can use this to reauthenticate and generate
a new Reddit token
- Reduce Tunestumbler token lifetime from 1 year to 3 weeks
- Increase minimum password length to 8 characters
- Changed the auth response model to reflect the above changes