### PR TITLE
Fixed SQL truncation error by increasing max results title length

### DIFF
--- a/src/main/java/ca/tunestumbler/api/io/entity/ResultsEntity.java
+++ b/src/main/java/ca/tunestumbler/api/io/entity/ResultsEntity.java
@@ -32,7 +32,7 @@ public class ResultsEntity implements Serializable {
 	@Column(nullable = false, length = 21)
 	private String subreddit;
 
-	@Column(nullable = false, length = 300)
+	@Column(nullable = false, length = 500)
 	private String title;
 
 	@Column(nullable = false)


### PR DESCRIPTION
- This bug occurred because subreddits can impose their own title
length limit, so the fix is to increase the results title length