### PR TITLE
Fixed losing previous filters when create new ones

### DIFF
--- a/src/main/java/ca/tunestumbler/api/io/entity/FiltersEntity.java
+++ b/src/main/java/ca/tunestumbler/api/io/entity/FiltersEntity.java
@@ -59,9 +59,6 @@ public class FiltersEntity implements Serializable {
 	private String showByDomain;
 
 	@Column()
-	private Long startId;
-
-	@Column()
 	private Boolean isActive = false;
 
 	@Column(nullable = false)
@@ -169,14 +166,6 @@ public class FiltersEntity implements Serializable {
 
 	public void setShowByDomain(String showByDomain) {
 		this.showByDomain = showByDomain;
-	}
-
-	public Long getStartId() {
-		return startId;
-	}
-
-	public void setStartId(Long startId) {
-		this.startId = startId;
 	}
 
 	public Boolean getIsActive() {

--- a/src/main/java/ca/tunestumbler/api/io/repositories/FiltersRepository.java
+++ b/src/main/java/ca/tunestumbler/api/io/repositories/FiltersRepository.java
@@ -9,21 +9,6 @@ import org.springframework.data.repository.query.Param;
 import ca.tunestumbler.api.io.entity.FiltersEntity;
 
 public interface FiltersRepository extends JpaRepository<FiltersEntity, String> {
-	FiltersEntity findByFiltersId(String filtersId);
-
-	@Query(value = "SELECT * FROM filters WHERE user_id = :userId", nativeQuery = true)
-	List<FiltersEntity> findFiltersByUserId(@Param("userId") String userId);
-
-	@Query(value = "SELECT MAX(id) FROM filters", nativeQuery = true)
-	Long findMaxId();
-
-	@Query(value = "SELECT MAX(id) FROM filters WHERE user_id = :userId", nativeQuery = true)
-	Long findMaxIdByUserId(@Param("userId") String userId);
-
-	@Query(value = "SELECT MAX(start_id) FROM filters WHERE user_id = :userId", nativeQuery = true)
-	Long findMaxStartIdByUserId(@Param("userId") String userId);
-
-	@Query(value = "SELECT * FROM filters WHERE user_id = :userId AND start_id >= :startId AND is_active = true", nativeQuery = true)
-	List<FiltersEntity> findFiltersByUserIdAndStartIdAndIsActive(@Param("userId") String userId,
-			@Param("startId") Long startId);
+	@Query(value = "SELECT * FROM filters WHERE user_id = :userId AND is_active = true", nativeQuery = true)
+	List<FiltersEntity> findFiltersByUserIdAndIsActive(@Param("userId") String userId);
 }

--- a/src/main/java/ca/tunestumbler/api/service/impl/FiltersServiceImpl.java
+++ b/src/main/java/ca/tunestumbler/api/service/impl/FiltersServiceImpl.java
@@ -45,15 +45,11 @@ public class FiltersServiceImpl implements FiltersService {
 		}.getType();
 		List<FiltersEntity> newFilters = new ModelMapper().map(filters, entityListType);
 
-		Long userMaxId = filtersRepository.findMaxIdByUserId(user.getUserId());
-		Long maxId = filtersRepository.findMaxId();
-		Long startId = sharedUtils.setStartId(userMaxId, maxId);
 		for (FiltersEntity newFilter : newFilters) {
 			String filtersId = sharedUtils.generateFiltersId(idLength);
 			newFilter.setFiltersId(filtersId);
 			newFilter.setUserEntity(userEntity);
 			newFilter.setUserId(user.getUserId());
-			newFilter.setStartId(startId);
 			newFilter.setIsActive(true);
 			newFilter.setLastModified(sharedUtils.getCurrentTime());
 		}
@@ -68,10 +64,9 @@ public class FiltersServiceImpl implements FiltersService {
 	@Override
 	public List<FiltersDTO> getFiltersByUserId(UserDTO user) {
 		String userId = user.getUserId();
-		Long startId = filtersRepository.findMaxStartIdByUserId(userId);
-		List<FiltersEntity> filtersList = filtersRepository.findFiltersByUserIdAndStartIdAndIsActive(userId, startId);
+		List<FiltersEntity> filtersList = filtersRepository.findFiltersByUserIdAndIsActive(userId);
 
-		if (filtersList == null) {
+		if (filtersList == null || filtersList.isEmpty()) {
 			throw new FiltersNotFoundException(ErrorPrefixes.FILTERS_SERVICE.getErrorPrefix()
 					+ ErrorMessages.FILTER_RESOURCES_NOT_FOUND.getErrorMessage());
 		}
@@ -85,9 +80,7 @@ public class FiltersServiceImpl implements FiltersService {
 	@Override
 	public List<FiltersDTO> updateFilters(UserDTO user, List<FiltersDTO> filters) {
 		String userId = user.getUserId();
-		Long startId = filtersRepository.findMaxStartIdByUserId(userId);
-		List<FiltersEntity> existingFilters = filtersRepository.findFiltersByUserIdAndStartIdAndIsActive(userId,
-				startId);
+		List<FiltersEntity> existingFilters = filtersRepository.findFiltersByUserIdAndIsActive(userId);
 
 		for (FiltersEntity filtersEntity : existingFilters) {
 			filtersEntity.setIsActive(false);
@@ -135,7 +128,6 @@ public class FiltersServiceImpl implements FiltersService {
 				newFilter.setShowByKeyword(filtersDTO.getShowByKeyword());
 				newFilter.setHideByDomain(filtersDTO.getHideByDomain());
 				newFilter.setShowByDomain(filtersDTO.getShowByDomain());
-				newFilter.setStartId(startId);
 				newFilter.setIsActive(true);
 				newFilter.setLastModified(sharedUtils.getCurrentTime());
 				updatedFiltersEntities.add(newFilter);

--- a/src/main/java/ca/tunestumbler/api/service/impl/ResultsServiceImpl.java
+++ b/src/main/java/ca/tunestumbler/api/service/impl/ResultsServiceImpl.java
@@ -61,10 +61,7 @@ public class ResultsServiceImpl implements ResultsService {
 	@Override
 	public ResultsResponseModel fetchResults(UserDTO user, String orderBy) {
 		String userId = user.getUserId();
-		Long filtersStartId = filtersRepository.findMaxStartIdByUserId(userId);
-
-		List<FiltersEntity> filters = filtersRepository.findFiltersByUserIdAndStartIdAndIsActive(userId,
-				filtersStartId);
+		List<FiltersEntity> filters = filtersRepository.findFiltersByUserIdAndIsActive(userId);
 		if (filters == null || filters.isEmpty()) {
 			throw new FiltersNotFoundException(ErrorPrefixes.RESULTS_SERVICE.getErrorPrefix()
 					+ ErrorMessages.FILTER_RESOURCES_NOT_FOUND.getErrorMessage());
@@ -139,9 +136,7 @@ public class ResultsServiceImpl implements ResultsService {
 		resultsRepository.saveAll(resultsEntities);
 		
 		List<ResultsEntity> filteredResults = new ArrayList<>();
-		Long filtersStartId = filtersRepository.findMaxStartIdByUserId(userId);
-		List<FiltersEntity> filters = filtersRepository.findFiltersByUserIdAndStartIdAndIsActive(userId,
-				filtersStartId);
+		List<FiltersEntity> filters = filtersRepository.findFiltersByUserIdAndIsActive(userId);
 
 		if (filters == null || filters.isEmpty()) {
 			throw new FiltersNotFoundException(ErrorPrefixes.RESULTS_SERVICE.getErrorPrefix()

--- a/src/main/java/ca/tunestumbler/api/shared/dto/FiltersDTO.java
+++ b/src/main/java/ca/tunestumbler/api/shared/dto/FiltersDTO.java
@@ -17,7 +17,6 @@ public class FiltersDTO implements Serializable {
 	private String showByKeyword;
 	private String hideByDomain;
 	private String showByDomain;
-	private Long startId;
 	private Boolean isActive = false;
 	private String lastModified;
 
@@ -123,14 +122,6 @@ public class FiltersDTO implements Serializable {
 
 	public void setShowByDomain(String showByDomain) {
 		this.showByDomain = showByDomain;
-	}
-
-	public Long getStartId() {
-		return startId;
-	}
-
-	public void setStartId(Long startId) {
-		this.startId = startId;
 	}
 
 	public Boolean getIsActive() {


### PR DESCRIPTION
- Remove `startId` from filters methods in Filters and Results
services, entity, DTO
- Originally wanted to use `startId` to keep track of the most
recent filters, but this instead causes a bug where the `startId` for
previous filters, that are actually still active but not included in
the `createFilters` request body, do not get incremented, and
ultimately do not get included with the most recent active filters
- `startId` is also unnecessary because the API can rely on
`is_active` field instead
- Removed query methods that looks for `startId` and modified query
methods to not use `startId` as a parameter
- Added `.isEmpty()` conditional checks for lists