### PR TITLE
Made aggregate service update methods more efficient

### DIFF
--- a/src/main/java/ca/tunestumbler/api/io/repositories/AggregateRepository.java
+++ b/src/main/java/ca/tunestumbler/api/io/repositories/AggregateRepository.java
@@ -9,19 +9,6 @@ import org.springframework.data.repository.query.Param;
 import ca.tunestumbler.api.io.entity.AggregateEntity;
 
 public interface AggregateRepository extends JpaRepository<AggregateEntity, String> {
-	AggregateEntity findByAggregateId(String aggregateId);
-
-	AggregateEntity findByUserId(String userId);
-
-	@Query(value = "SELECT * FROM aggregate WHERE user_id = :userId AND multireddit = :multireddit AND subreddit = :subreddit AND start_id >= :startId", nativeQuery = true)
-	List<AggregateEntity> findByUserIdAndMultiredditAndSubredditAndMaxStartId(@Param("userId") String userId,
-			@Param("multireddit") String multireddit, @Param("subreddit") String subreddit,
-			@Param("startId") Long startId);
-
-	@Query(value = "SELECT * FROM aggregate WHERE user_id = :userId AND subreddit = :subreddit AND start_id >= :startId", nativeQuery = true)
-	List<AggregateEntity> findByUserIdAndSubredditAndMaxStartId(@Param("userId") String userId,
-			@Param("subreddit") String subreddit, @Param("startId") Long startId);
-
 	@Query(value = "SELECT MAX(id) FROM aggregate", nativeQuery = true)
 	Long findMaxId();
 
@@ -32,10 +19,9 @@ public interface AggregateRepository extends JpaRepository<AggregateEntity, Stri
 	Long findMaxStartIdByUserId(@Param("userId") String userId);
 
 	@Query(value = "SELECT * FROM aggregate WHERE user_id = :userId AND start_id >= :startId", nativeQuery = true)
-	List<AggregateEntity> findAggregateByUserIdAndMaxStartId(@Param("userId") String userId,
-			@Param("startId") Long startId);
+	List<AggregateEntity> findByUserIdAndMaxStartId(@Param("userId") String userId,	@Param("startId") Long startId);
 
 	@Query(value = "SELECT * FROM aggregate WHERE user_id = :userId AND start_id >= :startId AND is_subreddit_added = true", nativeQuery = true)
-	List<AggregateEntity> findAggregateByUserIdAndMaxStartIdAndIsSubredditAdded(@Param("userId") String userId,
+	List<AggregateEntity> findByUserIdAndMaxStartIdAndIsSubredditAdded(@Param("userId") String userId,
 			@Param("startId") Long startId);
 }

--- a/src/main/java/ca/tunestumbler/api/ui/model/response/aggregate/AggregateObjectResponseModel.java
+++ b/src/main/java/ca/tunestumbler/api/ui/model/response/aggregate/AggregateObjectResponseModel.java
@@ -2,7 +2,6 @@ package ca.tunestumbler.api.ui.model.response.aggregate;
 
 public class AggregateObjectResponseModel {
 	private String aggregateId;
-	private String userId;
 	private String subredditId;
 	private String subreddit;
 	private String multiredditId;
@@ -15,14 +14,6 @@ public class AggregateObjectResponseModel {
 
 	public void setAggregateId(String aggregateId) {
 		this.aggregateId = aggregateId;
-	}
-
-	public String getUserId() {
-		return userId;
-	}
-
-	public void setUserId(String userId) {
-		this.userId = userId;
 	}
 
 	public String getSubredditId() {


### PR DESCRIPTION
- Instead of looping calls to the database to find if a subreddit is
currently subscribed or curated, make one call and map the results to
a two-key-one-value table
- This should reduce the number of database calls by the number of
subreddits the user is subscribed to/has curated in multireddits
- Removed aggregate unused methods and renamed `findAggregate`
methods to be slightly shorter
- Removed `startId` checks for `addSubredditEntity()` and
`addMultiredditEntity()` since the methods that call these will never
pass a null `startId` due to the logic of the startId
- Replaced `UserEntity` argument with `userId` string for
`addSubredditEntity()` and `addMultiredditEntity()` for simplicity