### PR TITLE
Added routes without userId path parameter

### DIFF
--- a/src/main/java/ca/tunestumbler/api/io/repositories/UserRepository.java
+++ b/src/main/java/ca/tunestumbler/api/io/repositories/UserRepository.java
@@ -10,9 +10,12 @@ import ca.tunestumbler.api.io.entity.UserEntity;
 @Repository
 public interface UserRepository extends PagingAndSortingRepository<UserEntity, String> {
 	UserEntity findByEmail(String email);
-	
+
 	UserEntity findByUserId(String userId);
-	
+
 	@Query(value = "SELECT email FROM users WHERE user_id = :userId", nativeQuery = true)
 	String findEmailByUserId(@Param("userId") String userId);
+
+	@Query(value = "SELECT user_id FROM users WHERE email = :email", nativeQuery = true)
+	String findUserIdByEmail(@Param("email") String email);
 }

--- a/src/main/java/ca/tunestumbler/api/service/impl/helpers/AuthorizationHelpers.java
+++ b/src/main/java/ca/tunestumbler/api/service/impl/helpers/AuthorizationHelpers.java
@@ -33,6 +33,11 @@ public class AuthorizationHelpers {
 	@Autowired
 	AuthenticationFacade authenticationFacade;
 
+	public String getUserIdFromAuth() {
+		String authenticationEmail = authenticationFacade.getAuthentication().getName();
+		return userRepository.findUserIdByEmail(authenticationEmail);
+	}
+
 	public void isAuthorized(String userId) {
 		String username = userRepository.findEmailByUserId(userId);
 		String authentication = authenticationFacade.getAuthentication().getName();

--- a/src/main/java/ca/tunestumbler/api/ui/controller/AggregateController.java
+++ b/src/main/java/ca/tunestumbler/api/ui/controller/AggregateController.java
@@ -38,6 +38,31 @@ public class AggregateController {
 	@Autowired
 	AuthorizationHelpers authorizationHelpers;
 
+	@GetMapping(path = "/create/myaggregate", produces = MediaType.APPLICATION_JSON_VALUE)
+	public AggregateResponseModel createMyAggregate() {
+		String userId = authorizationHelpers.getUserIdFromAuth();
+		if (Strings.isNullOrEmpty(userId)) {
+			throw new MissingPathParametersException(ErrorPrefixes.AGGREGATE_SERVICE.getErrorPrefix()
+					+ ErrorMessages.MISSING_REQUIRED_PATH_FIELD.getErrorMessage());
+		}
+		
+		/*
+		 * Token authorization validation
+		*/		
+		authorizationHelpers.isAuthorized(userId);
+
+		AggregateResponseModel aggregateResponse = new AggregateResponseModel();
+
+		UserDTO userDTO = userService.getUserByUserId(userId);
+		List<AggregateDTO> createdAggregate = aggregateService.createAggregateByUserId(userDTO);
+		Type listType = new TypeToken<List<AggregateObjectResponseModel>>() {
+		}.getType();
+		List<AggregateObjectResponseModel> responseObject = new ModelMapper().map(createdAggregate, listType);
+		aggregateResponse.setAggregate(responseObject);
+
+		return aggregateResponse;
+	}
+
 	@GetMapping(path = "/create/{userId}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public AggregateResponseModel createAggregate(@PathVariable String userId) {
 		if (Strings.isNullOrEmpty(userId)) {
@@ -62,6 +87,31 @@ public class AggregateController {
 		return aggregateResponse;
 	}
 
+	@GetMapping(path = "/update/myaggregate", produces = MediaType.APPLICATION_JSON_VALUE)
+	public AggregateResponseModel updateMyAggregate() {
+		String userId = authorizationHelpers.getUserIdFromAuth();
+		if (Strings.isNullOrEmpty(userId)) {
+			throw new MissingPathParametersException(ErrorPrefixes.AGGREGATE_SERVICE.getErrorPrefix()
+					+ ErrorMessages.MISSING_REQUIRED_PATH_FIELD.getErrorMessage());
+		}
+		
+		/*
+		 * Token authorization validation
+		*/		
+		authorizationHelpers.isAuthorized(userId);
+
+		AggregateResponseModel updatedAggregateResponse = new AggregateResponseModel();
+
+		UserDTO userDTO = userService.getUserByUserId(userId);
+		List<AggregateDTO> updatedAggregate = aggregateService.updateAggregateByUserId(userDTO);
+		Type listType = new TypeToken<List<AggregateObjectResponseModel>>() {
+		}.getType();
+		List<AggregateObjectResponseModel> responseObject = new ModelMapper().map(updatedAggregate, listType);
+		updatedAggregateResponse.setAggregate(responseObject);
+
+		return updatedAggregateResponse;
+	}
+
 	@GetMapping(path = "/update/{userId}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public AggregateResponseModel updateAggregate(@PathVariable String userId) {
 		if (Strings.isNullOrEmpty(userId)) {
@@ -84,6 +134,31 @@ public class AggregateController {
 		updatedAggregateResponse.setAggregate(responseObject);
 
 		return updatedAggregateResponse;
+	}
+
+	@GetMapping(path = "/myaggregate", produces = MediaType.APPLICATION_JSON_VALUE)
+	public AggregateResponseModel getMyAggregate() {
+		String userId = authorizationHelpers.getUserIdFromAuth();
+		if (Strings.isNullOrEmpty(userId)) {
+			throw new MissingPathParametersException(ErrorPrefixes.AGGREGATE_SERVICE.getErrorPrefix()
+					+ ErrorMessages.MISSING_REQUIRED_PATH_FIELD.getErrorMessage());
+		}
+		
+		/*
+		 * Token authorization validation
+		*/		
+		authorizationHelpers.isAuthorized(userId);
+
+		AggregateResponseModel aggregateResponse = new AggregateResponseModel();
+
+		UserDTO userDTO = userService.getUserByUserId(userId);
+		List<AggregateDTO> existingAggregate = aggregateService.getAggregateByUserId(userDTO);
+		Type listType = new TypeToken<List<AggregateObjectResponseModel>>() {
+		}.getType();
+		List<AggregateObjectResponseModel> responseObject = new ModelMapper().map(existingAggregate, listType);
+		aggregateResponse.setAggregate(responseObject);
+
+		return aggregateResponse;
 	}
 
 	@GetMapping(path = "/{userId}", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/ca/tunestumbler/api/ui/model/response/UserDetailsResponseModel.java
+++ b/src/main/java/ca/tunestumbler/api/ui/model/response/UserDetailsResponseModel.java
@@ -1,16 +1,7 @@
 package ca.tunestumbler.api.ui.model.response;
 
 public class UserDetailsResponseModel {
-	private String userId;
 	private String email;
-
-	public String getUserId() {
-		return userId;
-	}
-
-	public void setUserId(String userId) {
-		this.userId = userId;
-	}
 
 	public String getEmail() {
 		return email;

--- a/src/main/java/ca/tunestumbler/api/ui/model/response/multireddit/MultiredditObjectResponseModel.java
+++ b/src/main/java/ca/tunestumbler/api/ui/model/response/multireddit/MultiredditObjectResponseModel.java
@@ -4,7 +4,6 @@ public class MultiredditObjectResponseModel {
 	private String multiredditId;
 	private String multireddit;
 	private String subreddit;
-	private String userId;
 	private String lastModified;
 
 	public String getMultiredditId() {
@@ -29,14 +28,6 @@ public class MultiredditObjectResponseModel {
 
 	public void setSubreddit(String subreddit) {
 		this.subreddit = subreddit;
-	}
-
-	public String getUserId() {
-		return userId;
-	}
-
-	public void setUserId(String userId) {
-		this.userId = userId;
 	}
 
 	public String getLastModified() {

--- a/src/main/java/ca/tunestumbler/api/ui/model/response/results/ResultsObjectResponseModel.java
+++ b/src/main/java/ca/tunestumbler/api/ui/model/response/results/ResultsObjectResponseModel.java
@@ -2,7 +2,6 @@ package ca.tunestumbler.api.ui.model.response.results;
 
 public class ResultsObjectResponseModel {
 	private String resultsId;
-	private String userId;
 	private String subreddit;
 	private String title;
 	private int score;
@@ -22,14 +21,6 @@ public class ResultsObjectResponseModel {
 
 	public void setResultsId(String resultsId) {
 		this.resultsId = resultsId;
-	}
-
-	public String getUserId() {
-		return userId;
-	}
-
-	public void setUserId(String userId) {
-		this.userId = userId;
 	}
 
 	public String getSubreddit() {

--- a/src/main/java/ca/tunestumbler/api/ui/model/response/subreddit/SubredditObjectResponseModel.java
+++ b/src/main/java/ca/tunestumbler/api/ui/model/response/subreddit/SubredditObjectResponseModel.java
@@ -3,7 +3,6 @@ package ca.tunestumbler.api.ui.model.response.subreddit;
 public class SubredditObjectResponseModel {
 	private String subredditId;
 	private String subreddit;
-	private String userId;
 	private String afterId;
 	private String beforeId;
 	private String lastModified;
@@ -22,14 +21,6 @@ public class SubredditObjectResponseModel {
 
 	public void setSubreddit(String subreddit) {
 		this.subreddit = subreddit;
-	}
-
-	public String getUserId() {
-		return userId;
-	}
-
-	public void setUserId(String userId) {
-		this.userId = userId;
 	}
 
 	public String getAfterId() {


### PR DESCRIPTION
- Added routes that do not require `userId` as a path parameter so
that the `userId` does not need to be exposed to the client
- If the `userId` is not exposed to the client then it is less likely
to be leaked and abused
- Added a `UserRepository` method to find the `userId` from the
`email`, since the email can be extracted from the
`SecurityContextHolder` using the public method `getUserIdFromAuth()`
from `AuthenticationFacade`
- Removed `userId` from all response models
- Added `GET`, `PUT`, `DELETE` routes for `/myprofile`, which will
get, update, and delete user data
- Added `GET` for `/myprofile/clear_tokens` route to clear user
Reddit token and refresh token
- Added `GET` for `/connect` route to connect user Reddit account
- Added `GET` for `/refresh_token` to refresh user Reddit token
- Added `GET` for `/create/myaggregate` to create an aggregate for
user subreddits
- Added `GET` for `/update/myaggregate` to update aggregate for user
subreddits
- Added `GET` for `/myaggregate` to fetch user subreddits
- Added `GET`, `POST`, `PUT` for `/myfilters` to fetch, create, and
update user filters
- Added `GET` for `/fetch/myresults/{orderBy}` route to fetch
filtered results from Reddit
- Added `POST` for `/fetch/next` route to get the next page of
filtered results