### PR TITLE
Return NO_CONTENT responses and always require isActive

### DIFF
--- a/src/main/java/ca/tunestumbler/api/io/entity/FiltersEntity.java
+++ b/src/main/java/ca/tunestumbler/api/io/entity/FiltersEntity.java
@@ -52,7 +52,7 @@ public class FiltersEntity implements Serializable {
 	@Column(length = 15)
 	private String showByDomain;
 
-	@Column()
+	@Column(nullable = false)
 	private Boolean isActive;
 
 	@Column(nullable = false)

--- a/src/main/java/ca/tunestumbler/api/ui/controller/FiltersController.java
+++ b/src/main/java/ca/tunestumbler/api/ui/controller/FiltersController.java
@@ -115,6 +115,10 @@ public class FiltersController {
 			throw new InvalidBodyException(
 					ErrorPrefixes.FILTERS_SERVICE.getErrorPrefix() + ErrorMessages.INVALID_BODY.getErrorMessage());
 		}
+		
+		if (newFilters.getFilters().isEmpty()) {
+			return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+		}
 
 		UserDTO userDTO = userService.getUserByUserId(userId);
 		List<FiltersDTO> createdFilters = filtersService.createFilters(userDTO, newFilters.getFilters());
@@ -145,6 +149,10 @@ public class FiltersController {
 			throw new InvalidBodyException(
 					ErrorPrefixes.FILTERS_SERVICE.getErrorPrefix() + ErrorMessages.INVALID_BODY.getErrorMessage());
 		}
+		
+		if (newFilters.getFilters().isEmpty()) {
+			return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+		}
 
 		UserDTO userDTO = userService.getUserByUserId(userId);
 		List<FiltersDTO> createdFilters = filtersService.createFilters(userDTO, newFilters.getFilters());
@@ -159,7 +167,7 @@ public class FiltersController {
 	}
 
 	@PutMapping(path = "/myfilters", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-	public FiltersResponseModel updateMyFilters(@Valid @RequestBody FiltersRequestModel filtersToUpdate,
+	public ResponseEntity<?> updateMyFilters(@Valid @RequestBody FiltersRequestModel filtersToUpdate,
 			BindingResult bindingResult) {
 		String userId = authorizationHelpers.getUserIdFromAuth();
 		if (Strings.isNullOrEmpty(userId)) {
@@ -176,6 +184,10 @@ public class FiltersController {
 			throw new InvalidBodyException(
 					ErrorPrefixes.FILTERS_SERVICE.getErrorPrefix() + ErrorMessages.INVALID_BODY.getErrorMessage());
 		}
+		
+		if (filtersToUpdate.getFilters().isEmpty()) {
+			return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+		}
 
 		UserDTO userDTO = userService.getUserByUserId(userId);
 		List<FiltersDTO> updatedFilters = filtersService.updateFilters(userDTO, filtersToUpdate.getFilters());	
@@ -186,11 +198,11 @@ public class FiltersController {
 		FiltersResponseModel updatedFiltersResponse = new FiltersResponseModel();
 		updatedFiltersResponse.setFilters(responseObject);	
 
-		return updatedFiltersResponse;
+		return new ResponseEntity<>(updatedFiltersResponse, HttpStatus.OK);
 	}
 
 	@PutMapping(path = "/{userId}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-	public FiltersResponseModel updateFilters(@PathVariable String userId,
+	public ResponseEntity<?> updateFilters(@PathVariable String userId,
 			@Valid @RequestBody FiltersRequestModel filtersToUpdate, BindingResult bindingResult) {
 		if (Strings.isNullOrEmpty(userId)) {
 			throw new MissingPathParametersException(ErrorPrefixes.FILTERS_SERVICE.getErrorPrefix()
@@ -206,6 +218,10 @@ public class FiltersController {
 			throw new InvalidBodyException(
 					ErrorPrefixes.FILTERS_SERVICE.getErrorPrefix() + ErrorMessages.INVALID_BODY.getErrorMessage());
 		}
+		
+		if (filtersToUpdate.getFilters().isEmpty()) {
+			return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+		}
 
 		UserDTO userDTO = userService.getUserByUserId(userId);
 		List<FiltersDTO> updatedFilters = filtersService.updateFilters(userDTO, filtersToUpdate.getFilters());	
@@ -216,7 +232,7 @@ public class FiltersController {
 		FiltersResponseModel updatedFiltersResponse = new FiltersResponseModel();
 		updatedFiltersResponse.setFilters(responseObject);	
 
-		return updatedFiltersResponse;
+		return new ResponseEntity<>(updatedFiltersResponse, HttpStatus.OK);
 	}
 
 }

--- a/src/main/java/ca/tunestumbler/api/ui/model/request/FiltersRequestModel.java
+++ b/src/main/java/ca/tunestumbler/api/ui/model/request/FiltersRequestModel.java
@@ -2,7 +2,6 @@ package ca.tunestumbler.api.ui.model.request;
 
 import java.util.List;
 
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 import ca.tunestumbler.api.shared.dto.FiltersDTO;
@@ -10,7 +9,6 @@ import ca.tunestumbler.api.shared.dto.FiltersDTO;
 public class FiltersRequestModel {
 
 	@NotNull(message = "Filters cannot be null")
-	@NotEmpty(message = "Filters cannot be empty")
 	private List<FiltersDTO> filters;
 
 	public List<FiltersDTO> getFilters() {


### PR DESCRIPTION
- Return `NO_CONTENT` responses when `POST` or `PUT` filter request
bodies are empty
- Allow request bodies to contain an empty filters list
- Set the `isActive` column ` nullable` value to false, since this
property should always be sent with `filters` responses to tell the
API what filters are still active and which are not