### PR TITLE
Refactored auth service

### DIFF
--- a/src/main/java/ca/tunestumbler/api/service/AuthValidationService.java
+++ b/src/main/java/ca/tunestumbler/api/service/AuthValidationService.java
@@ -3,12 +3,9 @@ package ca.tunestumbler.api.service;
 import org.springframework.http.HttpHeaders;
 
 import ca.tunestumbler.api.shared.dto.AuthValidationDTO;
-import ca.tunestumbler.api.shared.dto.UserDTO;
 
 public interface AuthValidationService {
-	AuthValidationDTO createAuthState(UserDTO user);
-
-	AuthValidationDTO updateState(String stateId, String code);
+	AuthValidationDTO createAuthState(String userId);
 
 	HttpHeaders createHandlerHeaders(String state, String code);
 

--- a/src/main/java/ca/tunestumbler/api/service/impl/AuthValidationServiceImpl.java
+++ b/src/main/java/ca/tunestumbler/api/service/impl/AuthValidationServiceImpl.java
@@ -1,20 +1,11 @@
 package ca.tunestumbler.api.service.impl;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 
-import com.google.common.base.Strings;
-
-import ca.tunestumbler.api.exceptions.AuthValidationServiceException;
-import ca.tunestumbler.api.exceptions.ResourceNotFoundException;
 import ca.tunestumbler.api.io.entity.AuthValidationEntity;
-import ca.tunestumbler.api.io.entity.UserEntity;
-import ca.tunestumbler.api.io.repositories.AuthValidationRepository;
 import ca.tunestumbler.api.io.repositories.UserRepository;
 import ca.tunestumbler.api.service.AuthValidationService;
 import ca.tunestumbler.api.service.UserService;
@@ -22,21 +13,13 @@ import ca.tunestumbler.api.service.impl.helpers.AuthorizationHelpers;
 import ca.tunestumbler.api.shared.SharedUtils;
 import ca.tunestumbler.api.shared.dto.AuthValidationDTO;
 import ca.tunestumbler.api.shared.dto.UserDTO;
-import ca.tunestumbler.api.ui.model.response.ErrorMessages;
-import ca.tunestumbler.api.ui.model.response.ErrorPrefixes;
 import ca.tunestumbler.api.ui.model.response.auth.AuthResponseModel;
 
 @Service
 public class AuthValidationServiceImpl implements AuthValidationService {
 
 	@Autowired
-	AuthValidationService authValidationService;
-
-	@Autowired
 	UserService userService;
-	
-	@Autowired
-	AuthValidationRepository authValidationRepository;
 
 	@Autowired
 	UserRepository userRepository;
@@ -48,112 +31,52 @@ public class AuthValidationServiceImpl implements AuthValidationService {
 	AuthorizationHelpers authorizationHelpers;
 
 	@Override
-	public AuthValidationDTO createAuthState(UserDTO user) {
-		UserEntity userEntity = userRepository.findByUserId(user.getUserId());
-
-		if (userEntity == null) {
-			throw new ResourceNotFoundException(ErrorMessages.NO_RECORD_FOUND.getErrorMessage());
-		}
-
-		String stateId = sharedUtils.generateStateId(50);
-		String authorizationUrl = "https://www.reddit.com/api/v1/authorize" +
-				"?client_id=VvztT4RO6UUmAA" +
-				"&response_type=code" +
-				"&state=" + stateId +
-				"&redirect_uri=https://www.tunestumbler.com/" +
-				"&duration=permanent" +
-				"&scope=read,history,vote,save,account,subscribe,mysubreddits";
-		
-		AuthValidationEntity authValidationEntity = new AuthValidationEntity();
-
-		authValidationEntity.setStateId(stateId);
-		authValidationEntity.setUserId(userEntity.getUserId());
-		authValidationEntity.setLastModified(sharedUtils.getCurrentTime());
-		authValidationEntity.setAuthorizationUrl(authorizationUrl);
-
-		AuthValidationEntity storedAuthValidation = authValidationRepository.save(authValidationEntity);
+	public AuthValidationDTO createAuthState(String userId) {
+		AuthValidationEntity authValidationEntity = authorizationHelpers.createAuthValidationEntity(userId);
 
 		AuthValidationDTO authValidationDTO = new AuthValidationDTO();
-		BeanUtils.copyProperties(storedAuthValidation, authValidationDTO);
+		BeanUtils.copyProperties(authValidationEntity, authValidationDTO);
 
 		return authValidationDTO;
 	}
 
 	@Override
-	public AuthValidationDTO updateState(String stateId, String code) {
-		if (Strings.isNullOrEmpty(stateId) || Strings.isNullOrEmpty(code)) {
-			throw new AuthValidationServiceException(ErrorPrefixes.AUTH_SERVICE.getErrorPrefix()
-					+ ErrorMessages.BAD_REQUEST.getErrorMessage());
-		}
-
-		AuthValidationDTO authValiationToUpdate = new AuthValidationDTO();
-
-		AuthValidationEntity authValidationEntity = authValidationRepository.findByStateIdAndValidated(stateId, false);
-
-		if (authValidationEntity == null) {
-			throw new AuthValidationServiceException(ErrorPrefixes.AUTH_SERVICE.getErrorPrefix()
-					+ ErrorMessages.BAD_REQUEST.getErrorMessage());
-		}
-
-		authValidationEntity.setValidated(true);
-		authValidationEntity.setCode(code);
-		authValidationEntity.setLastModified(sharedUtils.getCurrentTime());
-
-		AuthValidationEntity updatedAuthValidation = authValidationRepository.save(authValidationEntity);
-		BeanUtils.copyProperties(updatedAuthValidation, authValiationToUpdate);
-
-		return authValiationToUpdate;
-	}
-
-	@Override
 	public HttpHeaders createHandlerHeaders(String state, String code) {
+		AuthValidationEntity authValidationEntity = authorizationHelpers.updateState(state, code);
+
 		AuthResponseModel response = authorizationHelpers.createRedditTokens(code);
-		String accessToken = response.getAccess_token();
-		String refreshToken = response.getRefresh_token();
-		String validScopes = "account history mysubreddits read save subscribe vote";
+		String tokenLifetime = Integer.toString(response.getExpires_in());
 
-		AuthValidationDTO updatedAuthValidationDTO = authValidationService.updateState(state, code);
-		HttpHeaders responseHeaders = new HttpHeaders();
-		if (accessToken != null && refreshToken != null	&& response.getScope().equals(validScopes)) {
-			UserDTO userDTO = userService.getUserByUserId(updatedAuthValidationDTO.getUserId());
+		if (response.getAccess_token() != null && response.getRefresh_token() != null 
+				&& authorizationHelpers.isScopesValid(response.getScope())) {
+			UserDTO userDTO = userService.getUserByUserId(authValidationEntity.getUserId());
+			userDTO.setToken(response.getAccess_token());
+			userDTO.setRefreshToken(response.getRefresh_token());
+			userDTO.setTokenLifetime(tokenLifetime);
+			userService.voidUpdateUser(userDTO.getUserId(), userDTO);
 
-			userDTO.setToken(accessToken);
-			userDTO.setRefreshToken(refreshToken);
-			userDTO.setTokenLifetime(Integer.toString(response.getExpires_in()));
-
-			List<String> exposedHeaders = new ArrayList<>();
-			String redditLifetimeHeader = "Reddit-Lifetime";
-			exposedHeaders.add(redditLifetimeHeader);
-			responseHeaders.setAccessControlExposeHeaders(exposedHeaders);
-			UserDTO updatedUser = userService.updateUser(userDTO.getUserId(), userDTO);
-			responseHeaders.set(redditLifetimeHeader, updatedUser.getTokenLifetime());
+			return authorizationHelpers.createResponseHeaders(tokenLifetime);
 		}
 		
-		return responseHeaders;
+		return new HttpHeaders();
 	}
 
 	@Override
 	public HttpHeaders createRefreshTokenHeaders(String userId) {
 		UserDTO userDTO = userService.getUserByUserId(userId);
 		AuthResponseModel response = authorizationHelpers.refreshRedditToken(userDTO.getRefreshToken());
-		String accessToken = response.getAccess_token();
 		String tokenLifetime = Integer.toString(response.getExpires_in());
-		String validScopes = "account history mysubreddits read save subscribe vote";
-
-		HttpHeaders responseHeaders = new HttpHeaders();
-		if (accessToken != null && !accessToken.isEmpty() && response.getScope().equals(validScopes)) {
-			userDTO.setToken(accessToken);
+		
+		if (response.getAccess_token() != null && !response.getAccess_token().isEmpty() 
+				&& authorizationHelpers.isScopesValid(response.getScope())) {
+			userDTO.setToken(response.getAccess_token());
 			userDTO.setTokenLifetime(tokenLifetime);
 			userService.voidUpdateUser(userId, userDTO);
-
-			List<String> exposedHeaders = new ArrayList<>();
-			String redditLifetimeHeader = "Reddit-Lifetime";
-			exposedHeaders.add(redditLifetimeHeader);
-			responseHeaders.setAccessControlExposeHeaders(exposedHeaders);
-			responseHeaders.set(redditLifetimeHeader, tokenLifetime);
+			
+			return authorizationHelpers.createResponseHeaders(tokenLifetime);
 		}
 
-		return responseHeaders;
+		return new HttpHeaders();
 	}
 	
 }

--- a/src/main/java/ca/tunestumbler/api/service/impl/helpers/AuthConstants.java
+++ b/src/main/java/ca/tunestumbler/api/service/impl/helpers/AuthConstants.java
@@ -1,0 +1,33 @@
+package ca.tunestumbler.api.service.impl.helpers;
+
+public final class AuthConstants {
+	
+	private AuthConstants() {};
+	
+	public static final String BASE_URL = "https://www.reddit.com";
+	public static final String AUTH_URI = "/api/v1/authorize";
+	public static final String CLIENT_ID_PARAMETER = "client_id=VvztT4RO6UUmAA";
+	public static final String RESPONSE_TYPE_PARAMETER = "response_type=code";
+	public static final String STATE_PARAMETER = "state=";
+	public static final String REDIRECT_URI_PARAMETER = "redirect_uri=";
+//	public static final String REDIRECT_URI = "https://www.tunestumbler.com/";
+	public static final String REDIRECT_URI = "http://localhost:8080/";
+	public static final String DURATION_PARAMETER = "duration=permanent";
+	public static final String SCOPE_PARAMETER = "scope=read,history,vote,save,account,subscribe,mysubreddits";
+	
+	public static final String ACCESS_TOKEN_URI = "/api/v1/access_token";
+	public static final String USER_AGENT_HEADER = "web:ca.tunestumbler.api:v1.0.0 (by /u/CrispiestHashbrown)";
+	public static final String REDDIT_LIFETIME_HEADER = "Reddit-Lifetime";
+	
+	public static final String AUTH_HEADER = "Basic ";
+	
+	public static final String GRANT_TYPE_HEADER = "grant_type";
+	public static final String AUTH_CODE_GRANT = "authorization_code";
+	public static final String REFRESH_TOKEN_GRANT = "refresh_token";
+	public static final String CODE_HEADER = "code";
+	public static final String REDIRECT_URI_HEADER = "redirect_uri";
+	public static final String REFRESH_TOKEN_HEADER = "refresh_token";
+	
+	public static final String VALID_SCOPES = "account history mysubreddits read save subscribe vote";
+	
+}

--- a/src/main/java/ca/tunestumbler/api/service/impl/helpers/AuthorizationHelpers.java
+++ b/src/main/java/ca/tunestumbler/api/service/impl/helpers/AuthorizationHelpers.java
@@ -1,7 +1,10 @@
 package ca.tunestumbler.api.service.impl.helpers;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -15,23 +18,35 @@ import org.springframework.web.reactive.function.BodyInserter;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import com.google.common.base.Strings;
+
+import ca.tunestumbler.api.io.entity.AuthValidationEntity;
+import ca.tunestumbler.api.io.repositories.AuthValidationRepository;
 import ca.tunestumbler.api.io.repositories.UserRepository;
 import ca.tunestumbler.api.security.AuthenticationFacade;
 import ca.tunestumbler.api.security.SecurityConstants;
+import ca.tunestumbler.api.shared.SharedUtils;
 import ca.tunestumbler.api.ui.model.response.ErrorMessages;
 import ca.tunestumbler.api.ui.model.response.ErrorPrefixes;
 import ca.tunestumbler.api.ui.model.response.auth.AuthResponseModel;
+import ca.tunestumbler.api.exceptions.AuthValidationServiceException;
 import ca.tunestumbler.api.exceptions.BadRequestException;
 import ca.tunestumbler.api.exceptions.WebRequestFailedException;
 
 @Component
 public class AuthorizationHelpers {
-
+	
 	@Autowired
 	UserRepository userRepository;
 
 	@Autowired
+	AuthValidationRepository authValidationRepository;
+
+	@Autowired
 	AuthenticationFacade authenticationFacade;
+	
+	@Autowired
+	SharedUtils sharedUtils;
 
 	public String getUserIdFromAuth() {
 		String authenticationEmail = authenticationFacade.getAuthentication().getName();
@@ -46,27 +61,46 @@ public class AuthorizationHelpers {
 		}
 	}
 
-	public AuthResponseModel refreshRedditToken(String refreshToken) {
-		String baseUrl = "https://www.reddit.com";
-		String uri = "/api/v1/access_token";
-		String userAgentHeader = "web:ca.tunestumbler.api:v0.0.1 (by /u/CrispiestHashbrown)";
-		String creds = Base64.getEncoder().encodeToString(SecurityConstants.getAuth().getBytes());
-		String authHeader = "Basic " + creds;
+	public AuthValidationEntity createAuthValidationEntity(String userId) {
+		String stateId = sharedUtils.generateStateId(50);
+		String authorizationUrl = AuthConstants.BASE_URL + AuthConstants.AUTH_URI
+				+ "?" + AuthConstants.CLIENT_ID_PARAMETER
+				+ "&" + AuthConstants.RESPONSE_TYPE_PARAMETER
+				+ "&" + AuthConstants.STATE_PARAMETER + stateId
+				+ "&" + AuthConstants.REDIRECT_URI_PARAMETER + AuthConstants.REDIRECT_URI
+				+ "&" + AuthConstants.DURATION_PARAMETER
+				+ "&" + AuthConstants.SCOPE_PARAMETER;
 
+		AuthValidationEntity authValidationEntity = new AuthValidationEntity();
+		
+		authValidationEntity.setStateId(stateId);
+		authValidationEntity.setUserId(userId);
+		authValidationEntity.setLastModified(sharedUtils.getCurrentTime());
+		authValidationEntity.setAuthorizationUrl(authorizationUrl);
+
+		authValidationRepository.save(authValidationEntity);
+
+		return authValidationEntity;
+	}
+	
+	public AuthResponseModel createRedditTokens(String code) {
+		String creds = Base64.getEncoder().encodeToString(SecurityConstants.getAuth().getBytes());
+		String authHeader = AuthConstants.AUTH_HEADER + creds;
 		WebClient client = WebClient
 				.builder()
-					.baseUrl(baseUrl)
-					.defaultHeader(HttpHeaders.USER_AGENT, userAgentHeader)
+					.baseUrl(AuthConstants.BASE_URL)
+					.defaultHeader(HttpHeaders.USER_AGENT, AuthConstants.USER_AGENT_HEADER)
 					.defaultHeader(HttpHeaders.AUTHORIZATION, authHeader)
 					.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
 					.defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
 				.build();
 		WebClient.UriSpec<WebClient.RequestBodySpec> request = client.method(HttpMethod.POST);
-		WebClient.RequestBodySpec requestUri = request.uri(uri);
+		WebClient.RequestBodySpec requestUri = request.uri(AuthConstants.ACCESS_TOKEN_URI);
 		
 		LinkedMultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-		map.add("grant_type", "refresh_token");
-		map.add("refresh_token", refreshToken);
+		map.add(AuthConstants.GRANT_TYPE_HEADER, AuthConstants.AUTH_CODE_GRANT);
+		map.add(AuthConstants.CODE_HEADER, code);
+		map.add(AuthConstants.REDIRECT_URI_HEADER, AuthConstants.REDIRECT_URI);
 		BodyInserter<MultiValueMap<String, Object>, ClientHttpRequest> inserter = BodyInserters.fromMultipartData(map);
 		return requestUri
 				.body(inserter)
@@ -84,29 +118,58 @@ public class AuthorizationHelpers {
 				.bodyToMono(AuthResponseModel.class)
 				.block();
 	}
+	
+	public Boolean isScopesValid(String scopes) {
+		return scopes.equals(AuthConstants.VALID_SCOPES);
+	}
+	
+	public HttpHeaders createResponseHeaders(String tokenLifetime) {
+		HttpHeaders responseHeaders = new HttpHeaders();
+		List<String> exposedHeaders = new ArrayList<>(Arrays.asList(AuthConstants.REDDIT_LIFETIME_HEADER));
+		responseHeaders.setAccessControlExposeHeaders(exposedHeaders);
+		responseHeaders.set(AuthConstants.REDDIT_LIFETIME_HEADER, tokenLifetime);
+		return responseHeaders;
+	}
 
-	public AuthResponseModel createRedditTokens(String code) {
-		String baseUrl = "https://www.reddit.com";
-		String uri = "/api/v1/access_token";
-		String userAgentHeader = "web:ca.tunestumbler.api:v0.0.1 (by /u/CrispiestHashbrown)";
+	public AuthValidationEntity updateState(String stateId, String code) {
+		if (Strings.isNullOrEmpty(stateId) || Strings.isNullOrEmpty(code)) {
+			throw new AuthValidationServiceException(ErrorPrefixes.AUTH_SERVICE.getErrorPrefix()
+					+ ErrorMessages.BAD_REQUEST.getErrorMessage());
+		}
+
+		AuthValidationEntity authValidationEntity = authValidationRepository.findByStateIdAndValidated(stateId, false);
+
+		if (authValidationEntity == null) {
+			throw new AuthValidationServiceException(ErrorPrefixes.AUTH_SERVICE.getErrorPrefix()
+					+ ErrorMessages.BAD_REQUEST.getErrorMessage());
+		}
+
+		authValidationEntity.setValidated(true);
+		authValidationEntity.setCode(code);
+		authValidationEntity.setLastModified(sharedUtils.getCurrentTime());
+		authValidationRepository.save(authValidationEntity);
+
+		return authValidationEntity;
+	}
+	
+	public AuthResponseModel refreshRedditToken(String refreshToken) {
 		String creds = Base64.getEncoder().encodeToString(SecurityConstants.getAuth().getBytes());
-		String authHeader = "Basic " + creds;
-		String redirectUri = "https://www.tunestumbler.com/";
+		String authHeader = AuthConstants.AUTH_HEADER + creds;
+
 		WebClient client = WebClient
 				.builder()
-					.baseUrl(baseUrl)
-					.defaultHeader(HttpHeaders.USER_AGENT, userAgentHeader)
+					.baseUrl(AuthConstants.BASE_URL)
+					.defaultHeader(HttpHeaders.USER_AGENT, AuthConstants.USER_AGENT_HEADER)
 					.defaultHeader(HttpHeaders.AUTHORIZATION, authHeader)
 					.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
 					.defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
 				.build();
 		WebClient.UriSpec<WebClient.RequestBodySpec> request = client.method(HttpMethod.POST);
-		WebClient.RequestBodySpec requestUri = request.uri(uri);
+		WebClient.RequestBodySpec requestUri = request.uri(AuthConstants.ACCESS_TOKEN_URI);
 		
 		LinkedMultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-		map.add("grant_type", "authorization_code");
-		map.add("code", code);
-		map.add("redirect_uri", redirectUri);
+		map.add(AuthConstants.GRANT_TYPE_HEADER, AuthConstants.REFRESH_TOKEN_GRANT);
+		map.add(AuthConstants.REFRESH_TOKEN_HEADER, refreshToken);
 		BodyInserter<MultiValueMap<String, Object>, ClientHttpRequest> inserter = BodyInserters.fromMultipartData(map);
 		return requestUri
 				.body(inserter)

--- a/src/main/java/ca/tunestumbler/api/ui/controller/AuthValidationController.java
+++ b/src/main/java/ca/tunestumbler/api/ui/controller/AuthValidationController.java
@@ -16,12 +16,12 @@ import org.springframework.web.bind.annotation.RestController;
 import com.google.common.base.Strings;
 
 import ca.tunestumbler.api.exceptions.MissingPathParametersException;
+import ca.tunestumbler.api.exceptions.ResourceNotFoundException;
 import ca.tunestumbler.api.service.AuthValidationService;
 import ca.tunestumbler.api.service.UserService;
 import ca.tunestumbler.api.service.impl.helpers.AuthorizationHelpers;
 import ca.tunestumbler.api.shared.SharedUtils;
 import ca.tunestumbler.api.shared.dto.AuthValidationDTO;
-import ca.tunestumbler.api.shared.dto.UserDTO;
 import ca.tunestumbler.api.ui.model.response.ErrorMessages;
 import ca.tunestumbler.api.ui.model.response.ErrorPrefixes;
 import ca.tunestumbler.api.ui.model.response.auth.AuthConnectResponseModel;
@@ -55,8 +55,11 @@ public class AuthValidationController {
 		 */
 		authorizationHelpers.isAuthorized(userId);
 
-		UserDTO userDTO = userService.getUserByUserId(userId);
-		AuthValidationDTO authValidationDTO = authValidationService.createAuthState(userDTO);
+		if (userService.getUserByUserId(userId) == null) {
+			throw new ResourceNotFoundException(ErrorMessages.NO_RECORD_FOUND.getErrorMessage());
+		}
+
+		AuthValidationDTO authValidationDTO = authValidationService.createAuthState(userId);
 
 		AuthConnectResponseModel authConnectResponseModel = new AuthConnectResponseModel();
 		BeanUtils.copyProperties(authValidationDTO, authConnectResponseModel);
@@ -76,8 +79,11 @@ public class AuthValidationController {
 		 */
 		authorizationHelpers.isAuthorized(userId);
 
-		UserDTO userDTO = userService.getUserByUserId(userId);
-		AuthValidationDTO authValidationDTO = authValidationService.createAuthState(userDTO);
+		if (userService.getUserByUserId(userId) == null) {
+			throw new ResourceNotFoundException(ErrorMessages.NO_RECORD_FOUND.getErrorMessage());
+		}
+		
+		AuthValidationDTO authValidationDTO = authValidationService.createAuthState(userId);
 
 		AuthConnectResponseModel authConnectResponseModel = new AuthConnectResponseModel();
 		BeanUtils.copyProperties(authValidationDTO, authConnectResponseModel);


### PR DESCRIPTION
- Updated user agent header to reflect current API version
- Refactored `createAuthState` to take `userId` instead of the entire
 `UserDTO`, since passing the `UserDTO` as an argument is overkill.
- Separated creating the `AuthValidationEntity` into a separate
helper method from `createAuthState` impl method so that the code is
easier to read and test
- Separated creating response headers into a separate helper method
so that this can be reused in `createHandlerHeaders` and
`createRefreshTokenHeaders`, and also so that the response headers
can now be tested separately
- Separated constants from `AuthorizationHelpers` into a separate
constants class, `AuthConstants` so that it is easier to keep track
and maintain them
- Created a separate method to check if the Reddit scopes are the
correct scopes, instead of validating against a hard-coded string