### PR TITLE
Added error handler for Reddit rate limit errors

### DIFF
--- a/src/main/java/ca/tunestumbler/api/exceptions/ApplicationExceptionsHandler.java
+++ b/src/main/java/ca/tunestumbler/api/exceptions/ApplicationExceptionsHandler.java
@@ -135,6 +135,19 @@ public class ApplicationExceptionsHandler {
 		return new ResponseEntity<>(createErrorsResponse(errorObject), httpStatus);
 	}
 
+	@ExceptionHandler(value = { TooManyRequestsFailedException.class })
+	public ResponseEntity<Object> handleTooManyRequestsFailedException(TooManyRequestsFailedException exception,
+			WebRequest request) {
+		HttpStatus httpStatus = HttpStatus.TOO_MANY_REQUESTS;
+		ErrorObject errorObject = new ErrorObject(
+				httpStatus.toString(),
+				"TOO MANY REDDIT REQUESTS",
+				exception.getMessage(),
+				sharedUtils.getCurrentTime());
+
+		return new ResponseEntity<>(createErrorsResponse(errorObject), httpStatus);
+	}
+	
 	@ExceptionHandler(value = { WebRequestFailedException.class })
 	public ResponseEntity<Object> handleWebRequestFailedException(WebRequestFailedException exception,
 			WebRequest request) {

--- a/src/main/java/ca/tunestumbler/api/service/impl/helpers/MultiredditHelpers.java
+++ b/src/main/java/ca/tunestumbler/api/service/impl/helpers/MultiredditHelpers.java
@@ -3,11 +3,13 @@ package ca.tunestumbler.api.service.impl.helpers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import ca.tunestumbler.api.exceptions.RedditAccountNotAuthenticatedException;
+import ca.tunestumbler.api.exceptions.TooManyRequestsFailedException;
 import ca.tunestumbler.api.exceptions.WebRequestFailedException;
 import ca.tunestumbler.api.security.SecurityConstants;
 import ca.tunestumbler.api.shared.SharedUtils;
@@ -50,7 +52,11 @@ public class MultiredditHelpers {
 		return requestUri
 						.exchange()
 						.map(clientResponse -> {
-							if (clientResponse.statusCode().isError()) {
+							if (clientResponse.statusCode().equals(HttpStatus.TOO_MANY_REQUESTS)) {
+								throw new TooManyRequestsFailedException(ErrorPrefixes.MULTIREDDIT_SERVICE.getErrorPrefix()
+										+ ErrorMessages.TOO_MANY_REDDIT_REQUESTS.getErrorMessage() 
+										+ clientResponse.headers().header("x-ratelimit-reset") + " seconds");
+							} else if (clientResponse.statusCode().isError()) {
 								throw new WebRequestFailedException(ErrorPrefixes.MULTIREDDIT_SERVICE.getErrorPrefix()
 										+ ErrorMessages.FAILED_EXTERNAL_WEB_REQUEST.getErrorMessage());
 							}

--- a/src/main/java/ca/tunestumbler/api/service/impl/helpers/SubredditHelpers.java
+++ b/src/main/java/ca/tunestumbler/api/service/impl/helpers/SubredditHelpers.java
@@ -3,11 +3,13 @@ package ca.tunestumbler.api.service.impl.helpers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import ca.tunestumbler.api.exceptions.RedditAccountNotAuthenticatedException;
+import ca.tunestumbler.api.exceptions.TooManyRequestsFailedException;
 import ca.tunestumbler.api.exceptions.WebRequestFailedException;
 import ca.tunestumbler.api.security.SecurityConstants;
 import ca.tunestumbler.api.shared.SharedUtils;
@@ -49,11 +51,14 @@ public class SubredditHelpers {
 		return requestUri
 						.exchange()
 						.map(clientResponse -> {
-							if (clientResponse.statusCode().isError()) {
+							if (clientResponse.statusCode().equals(HttpStatus.TOO_MANY_REQUESTS)) {
+								throw new TooManyRequestsFailedException(ErrorPrefixes.SUBREDDIT_SERVICE.getErrorPrefix()
+										+ ErrorMessages.TOO_MANY_REDDIT_REQUESTS.getErrorMessage() 
+										+ clientResponse.headers().header("x-ratelimit-reset") + " seconds");
+							} else if (clientResponse.statusCode().isError()) {
 								throw new WebRequestFailedException(ErrorPrefixes.SUBREDDIT_SERVICE.getErrorPrefix()
 										+ ErrorMessages.FAILED_EXTERNAL_WEB_REQUEST.getErrorMessage());
 							}
-
 							return clientResponse;
 					    })
 						.block()

--- a/src/main/java/ca/tunestumbler/api/ui/model/response/ErrorMessages.java
+++ b/src/main/java/ca/tunestumbler/api/ui/model/response/ErrorMessages.java
@@ -16,7 +16,8 @@ public enum ErrorMessages {
 	COULD_NOT_DELETE_RECORD("Could not delete record"),
 	EMAIL_ADDRESS_NOT_VERIFIED("Email address could not be verified"),
 	BAD_REQUEST("Bad request"),
-	COULD_NOT_GENERATE_UNIQUE_STATE("Could not generate unique state. Try again");
+	COULD_NOT_GENERATE_UNIQUE_STATE("Could not generate unique state. Try again"),
+	TOO_MANY_REDDIT_REQUESTS("Too many requests to the Reddit API have been made. Please try again after: ");
 	
 	private String errorMessage;
 


### PR DESCRIPTION
- The Reddit API has a 600 request per 10 minutes rate limit. So,
added exception handler to handle `429: Too Many Requests` error
from the Reddit API
- Added this error handler to subreddit, multireddit, and results
`WebClient` helper method requests to the Reddit API
- Reddit auth requests are not affected by the rate limit, so did
not add the exception handler to the Auth requests