### PR TITLE
Refactored and reworked Results controller and service

### DIFF
--- a/src/main/java/ca/tunestumbler/api/exceptions/ApplicationExceptionsHandler.java
+++ b/src/main/java/ca/tunestumbler/api/exceptions/ApplicationExceptionsHandler.java
@@ -72,7 +72,7 @@ public class ApplicationExceptionsHandler {
 	}
 
 	@ExceptionHandler(value = { RedditAccountNotAuthenticatedException.class })
-	public ResponseEntity<Object> handleAuthValidationServiceException(RedditAccountNotAuthenticatedException exception,
+	public ResponseEntity<Object> handleRedditAccountNotAuthenticatedException(RedditAccountNotAuthenticatedException exception,
 			WebRequest request) {
 		HttpStatus httpStatus = HttpStatus.UNAUTHORIZED;
 		ErrorObject errorObject = new ErrorObject(

--- a/src/main/java/ca/tunestumbler/api/io/repositories/specification/ResultsSpecification.java
+++ b/src/main/java/ca/tunestumbler/api/io/repositories/specification/ResultsSpecification.java
@@ -1,81 +1,59 @@
 package ca.tunestumbler.api.io.repositories.specification;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
 import org.springframework.data.jpa.domain.Specification;
 
 import ca.tunestumbler.api.io.entity.ResultsEntity;
 
-public class ResultsSpecification {
+public class ResultsSpecification implements Specification<ResultsEntity> {
+	private static final long serialVersionUID = -244093893557352665L;
 
-	public static Specification<ResultsEntity> withUserId(String userId) {
-		if (userId == null || userId.isEmpty()) {
-			return null;
-		} else {
-			return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("userId"), userId);
+	private List<SearchCriteria> list;
+
+	public ResultsSpecification() {
+		this.list = new ArrayList<>();
+	}
+
+	public void add(SearchCriteria criteria) {
+		if (!(criteria.getValue() == null || criteria.getValue().toString().isEmpty())) {
+			this.list.add(criteria);
 		}
 	}
 
-	public static Specification<ResultsEntity> withStartId(Long startId) {
-		if (startId == null) {
-			return null;
-		} else {
-			return (root, query, criteriaBuilder) -> criteriaBuilder.ge(root.get("startId"), startId);
+	@Override
+	public Predicate toPredicate(Root<ResultsEntity> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder) {
+		List<Predicate> predicates = new ArrayList<>();
+		for (SearchCriteria criteria : list) {
+			if (criteria.getOperation().equals(SearchOperation.EQUAL)) {
+				if (isString(criteria.getValue())) {
+					predicates.add(criteriaBuilder.equal(root.get(criteria.getField()),
+							criteria.getValue().toString().toLowerCase()));
+				} else {
+					predicates.add(criteriaBuilder.equal(root.get(criteria.getField()), criteria.getValue()));
+				}
+			} else if (criteria.getOperation().equals(SearchOperation.GREATER_THAN_OR_EQUAL)) {
+				predicates.add(criteriaBuilder.ge(root.get(criteria.getField()), (Number) criteria.getValue()));
+			} else if (criteria.getOperation().equals(SearchOperation.LIKE)) {
+				predicates.add(criteriaBuilder.like(root.get(criteria.getField()),
+						"%" + criteria.getValue().toString().toLowerCase() + "%"));
+			} else if (criteria.getOperation().equals(SearchOperation.NOT_LIKE)) {
+				predicates.add(criteriaBuilder.notLike(root.get(criteria.getField()),
+						"%" + criteria.getValue().toString().toLowerCase() + "%"));
+			}
 		}
+
+		return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
 	}
 
-	public static Specification<ResultsEntity> withSubreddit(String subreddit) {
-		if (subreddit == null || subreddit.isEmpty()) {
-			return null;
-		} else {
-			return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("subreddit"), subreddit);
-		}
-	}
-
-	public static Specification<ResultsEntity> withMinScore(Integer score) {
-		if (score == null) {
-			return null;
-		} else {
-			return (root, query, criteriaBuilder) -> criteriaBuilder.ge(root.get("score"), score);
-		}
-	}
-
-	public static Specification<ResultsEntity> withNSFW(Boolean isNsfw) {
-		if (isNsfw == null) {
-			return null;
-		} else {
-			return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("isNsfw"), isNsfw);
-		}
-	}
-
-	public static Specification<ResultsEntity> withDomainOnly(String domain) {
-		if (domain == null || domain.isEmpty()) {
-			return null;
-		} else {
-			return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("domain"), "%" + domain + "%");
-		}
-	}
-
-	public static Specification<ResultsEntity> withoutDomain(String domain) {
-		if (domain == null || domain.isEmpty()) {
-			return null;
-		} else {
-			return (root, query, criteriaBuilder) -> criteriaBuilder.notLike(root.get("domain"), "%" + domain + "%");
-		}
-	}
-
-	public static Specification<ResultsEntity> withTitleKeyword(String keyword) {
-		if (keyword == null || keyword.isEmpty()) {
-			return null;
-		} else {
-			return (root, query, criteriaBuilder) -> criteriaBuilder.like(root.get("title"), "%" + keyword + "%");
-		}
-	}
-
-	public static Specification<ResultsEntity> withoutTitleKeyword(String keyword) {
-		if (keyword == null || keyword.isEmpty()) {
-			return null;
-		} else {
-			return (root, query, criteriaBuilder) -> criteriaBuilder.notLike(root.get("title"), "%" + keyword +  "%");
-		}
+	private boolean isString(Object any) {
+		return any instanceof String;
 	}
 
 }

--- a/src/main/java/ca/tunestumbler/api/io/repositories/specification/SearchCriteria.java
+++ b/src/main/java/ca/tunestumbler/api/io/repositories/specification/SearchCriteria.java
@@ -1,0 +1,41 @@
+package ca.tunestumbler.api.io.repositories.specification;
+
+public class SearchCriteria {
+	private Object value;
+	private String field;
+	private SearchOperation operation;
+
+	public SearchCriteria() {
+	}
+
+	public SearchCriteria(Object value, String field, SearchOperation operation) {
+		this.value = value;
+		this.field = field;
+		this.operation = operation;
+	}
+
+	public Object getValue() {
+		return value;
+	}
+
+	public void setValue(Object value) {
+		this.value = value;
+	}
+
+	public String getField() {
+		return field;
+	}
+
+	public void setField(String field) {
+		this.field = field;
+	}
+
+	public SearchOperation getOperation() {
+		return operation;
+	}
+
+	public void setOperation(SearchOperation operation) {
+		this.operation = operation;
+	}
+
+}

--- a/src/main/java/ca/tunestumbler/api/io/repositories/specification/SearchOperation.java
+++ b/src/main/java/ca/tunestumbler/api/io/repositories/specification/SearchOperation.java
@@ -1,0 +1,8 @@
+package ca.tunestumbler.api.io.repositories.specification;
+
+public enum SearchOperation {
+	EQUAL,
+	GREATER_THAN_OR_EQUAL,
+	LIKE,
+	NOT_LIKE
+}

--- a/src/main/java/ca/tunestumbler/api/io/repositories/specification/SortResultsById.java
+++ b/src/main/java/ca/tunestumbler/api/io/repositories/specification/SortResultsById.java
@@ -1,4 +1,4 @@
-package ca.tunestumbler.api.shared;
+package ca.tunestumbler.api.io.repositories.specification;
 
 import java.util.Comparator;
 

--- a/src/main/java/ca/tunestumbler/api/service/ResultsService.java
+++ b/src/main/java/ca/tunestumbler/api/service/ResultsService.java
@@ -1,10 +1,11 @@
 package ca.tunestumbler.api.service;
 
+import ca.tunestumbler.api.shared.dto.NextResultsRequestDTO;
 import ca.tunestumbler.api.shared.dto.UserDTO;
 import ca.tunestumbler.api.ui.model.response.ResultsResponseModel;
 
 public interface ResultsService {
 	ResultsResponseModel fetchResults(UserDTO user, String orderBy);
 
-	ResultsResponseModel fetchNextResults(UserDTO user, String nextUri, String nextAfterId);
+	ResultsResponseModel fetchNextResults(UserDTO user, NextResultsRequestDTO nextResultsRequestDTO);
 }

--- a/src/main/java/ca/tunestumbler/api/service/impl/ResultsServiceImpl.java
+++ b/src/main/java/ca/tunestumbler/api/service/impl/ResultsServiceImpl.java
@@ -1,16 +1,10 @@
 package ca.tunestumbler.api.service.impl;
 
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 
-import org.modelmapper.ModelMapper;
-import org.modelmapper.TypeToken;
-import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -22,32 +16,36 @@ import ca.tunestumbler.api.exceptions.FiltersNotFoundException;
 import ca.tunestumbler.api.exceptions.RedditAccountNotAuthenticatedException;
 import ca.tunestumbler.api.exceptions.TooManyRequestsFailedException;
 import ca.tunestumbler.api.exceptions.WebRequestFailedException;
+import ca.tunestumbler.api.io.entity.ExcludedDomainEntity;
+import ca.tunestumbler.api.io.entity.ExcludedKeywordEntity;
 import ca.tunestumbler.api.io.entity.FiltersEntity;
 import ca.tunestumbler.api.io.entity.ResultsEntity;
-import ca.tunestumbler.api.io.entity.UserEntity;
+import ca.tunestumbler.api.io.entity.SelectedDomainEntity;
+import ca.tunestumbler.api.io.entity.SelectedKeywordEntity;
 import ca.tunestumbler.api.io.repositories.FiltersRepository;
 import ca.tunestumbler.api.io.repositories.ResultsRepository;
 import ca.tunestumbler.api.io.repositories.UserRepository;
 import ca.tunestumbler.api.security.SecurityConstants;
 import ca.tunestumbler.api.service.ResultsService;
 import ca.tunestumbler.api.shared.SharedUtils;
-import ca.tunestumbler.api.shared.SortResultsById;
+import ca.tunestumbler.api.shared.dto.NextResultsRequestDTO;
+import ca.tunestumbler.api.shared.dto.ResultsDTO;
 import ca.tunestumbler.api.shared.dto.UserDTO;
+import ca.tunestumbler.api.shared.mapper.ResultsMapper;
 import ca.tunestumbler.api.ui.model.response.ErrorMessages;
 import ca.tunestumbler.api.ui.model.response.ErrorPrefixes;
 import ca.tunestumbler.api.ui.model.response.ResultsResponseModel;
-import ca.tunestumbler.api.ui.model.response.results.ResultsDataChildrenDataModel;
 import ca.tunestumbler.api.ui.model.response.results.ResultsDataChildrenModel;
 import ca.tunestumbler.api.ui.model.response.results.ResultsFetchResponseModel;
 import ca.tunestumbler.api.ui.model.response.results.ResultsObjectResponseModel;
 import ca.tunestumbler.api.io.repositories.specification.ResultsSpecification;
+import ca.tunestumbler.api.io.repositories.specification.SearchCriteria;
+import ca.tunestumbler.api.io.repositories.specification.SearchOperation;
+import ca.tunestumbler.api.io.repositories.specification.SortResultsById;
 
 @Service
 public class ResultsServiceImpl implements ResultsService {
 
-	private int idLength = 50;
-	private String afterIdPathVariableName = "&after=";
-	
 	@Autowired
 	ResultsRepository resultsRepository;
 
@@ -60,140 +58,91 @@ public class ResultsServiceImpl implements ResultsService {
 	@Autowired
 	SharedUtils sharedUtils;
 
+	@Autowired
+	ResultsMapper resultsMapper;
+
 	@Override
 	public ResultsResponseModel fetchResults(UserDTO user, String orderBy) {
 		String userId = user.getUserId();
-		List<FiltersEntity> filters = filtersRepository.findFiltersByUserIdAndIsActive(userId);
+		List<FiltersEntity> filters = filtersRepository.findFiltersByUserId(userId);
 		if (filters == null || filters.isEmpty()) {
 			throw new FiltersNotFoundException(ErrorPrefixes.RESULTS_SERVICE.getErrorPrefix()
 					+ ErrorMessages.FILTER_RESOURCES_NOT_FOUND.getErrorMessage());
 		}
 
-		String baseUrl = "https://oauth.reddit.com";
-		String uri = filtersURIBuilder(filters, orderBy);
-		ResultsFetchResponseModel response = sendGetResultsRequest(user, baseUrl, uri);
+		String uri = filtersUriBuilder(filters, orderBy);
+		ResultsFetchResponseModel response = sendGetResultsRequest(user, uri);
 		List<ResultsDataChildrenModel> resultsModel = response.getData().getChildren();
 		if (resultsModel == null || resultsModel.isEmpty()
 				|| resultsModel.size() < 2 && resultsModel.get(0).getData().getStickied()) {
 			return new ResultsResponseModel();
 		}
 
-		UserEntity userEntity = new UserEntity();
-		BeanUtils.copyProperties(user, userEntity);
-
+		List<ResultsDTO> resultDTOs = resultsMapper.resultsDataChildrenListToResultsDTOlist(resultsModel);
 		Long maxId = setResultsStartId(userId);
+		resultsRepository.saveAll(resultsMapper.resultsDTOlistToResultsEntityList(resultDTOs, userId, maxId));
+
 		String afterId = response.getData().getAfter();
-		List<ResultsEntity> resultsEntities = new ArrayList<>();
-		for (ResultsDataChildrenModel data : resultsModel) {
-			ResultsEntity resultsEntity = addResultsEntity(userEntity, data.getData(), maxId);
-			resultsEntities.add(resultsEntity);
-		}
-
-		resultsRepository.saveAll(resultsEntities);
-		
-		List<ResultsEntity> filteredResults = new ArrayList<>();
-		for (FiltersEntity filtersEntity : filters) {
-			filteredResults.addAll(getFilteredResults(filtersEntity, userId, maxId));
-		}
-
-		List<ResultsEntity> filteredResultsWithoutDuplicates = new ArrayList<>(new HashSet<>(filteredResults));
-		Collections.sort(filteredResultsWithoutDuplicates, new SortResultsById());
-		
-		ResultsResponseModel results = new ResultsResponseModel();
-		Type listType = new TypeToken<List<ResultsObjectResponseModel>>() {
-		}.getType();
-		List<ResultsObjectResponseModel> responseObject = new ModelMapper().map(filteredResultsWithoutDuplicates, listType);
-		results.setResults(responseObject);
-		results.setAfterId(afterId);
-		results.setNextUri(uri);
-		
-		return results;
+		List<ResultsObjectResponseModel> responseObjects = buildFilteredResultObjects(filters, maxId);
+		return resultsMapper.buildResponseModel(responseObjects, afterId, uri);
 	}
 
 	@Override
-	public ResultsResponseModel fetchNextResults(UserDTO user, String nextUri, String afterId) {
-		String baseUrl = "https://oauth.reddit.com";
-		String fullUri = nextUri + afterIdPathVariableName + afterId;
+	public ResultsResponseModel fetchNextResults(UserDTO user, NextResultsRequestDTO nextResultsRequestDTO) {
+		String userId = user.getUserId();
+		List<FiltersEntity> filters = filtersRepository.findFiltersByUserId(userId);
+		if (filters == null || filters.isEmpty()) {
+			throw new FiltersNotFoundException(ErrorPrefixes.RESULTS_SERVICE.getErrorPrefix()
+					+ ErrorMessages.FILTER_RESOURCES_NOT_FOUND.getErrorMessage());
+		}
 
-		ResultsFetchResponseModel response = sendGetResultsRequest(user, baseUrl, fullUri);
+		String fullUri = nextResultsRequestDTO.getNextUri() + "&after=" + nextResultsRequestDTO.getAfterId();
+		ResultsFetchResponseModel response = sendGetResultsRequest(user, fullUri);
 		List<ResultsDataChildrenModel> resultsModel = response.getData().getChildren();
 		if (resultsModel == null || resultsModel.isEmpty()
 				|| resultsModel.size() < 2 && resultsModel.get(0).getData().getStickied()) {
 			return new ResultsResponseModel();
 		}
 
-		UserEntity userEntity = new UserEntity();
-		BeanUtils.copyProperties(user, userEntity);
-
-		String userId = user.getUserId();
 		Long newStartId = setResultsStartId(userId);
+		List<ResultsDTO> resultDTOs = resultsMapper.resultsDataChildrenListToResultsDTOlist(resultsModel);
+		resultsRepository.saveAll(resultsMapper.resultsDTOlistToResultsEntityList(resultDTOs, userId, newStartId));
 
 		String nextAfterId = response.getData().getAfter();
-		List<ResultsEntity> resultsEntities = new ArrayList<>();
-		for (ResultsDataChildrenModel data : resultsModel) {
-			ResultsEntity resultsEntity = addResultsEntity(userEntity, data.getData(), newStartId);
-			resultsEntities.add(resultsEntity);
-		}
+		List<ResultsObjectResponseModel> responseObjects = buildFilteredResultObjects(filters, newStartId);
+		return resultsMapper.buildResponseModel(responseObjects, nextAfterId, nextResultsRequestDTO.getNextUri());
+	}
 
-		resultsRepository.saveAll(resultsEntities);
-		
-		List<ResultsEntity> filteredResults = new ArrayList<>();
-		List<FiltersEntity> filters = filtersRepository.findFiltersByUserIdAndIsActive(userId);
-
-		if (filters == null || filters.isEmpty()) {
-			throw new FiltersNotFoundException(ErrorPrefixes.RESULTS_SERVICE.getErrorPrefix()
-					+ ErrorMessages.FILTER_RESOURCES_NOT_FOUND.getErrorMessage());
-		}
-
+	private String filtersUriBuilder(List<FiltersEntity> filters, String orderBy) {
+		StringBuilder subreddits = new StringBuilder("");
 		for (FiltersEntity filtersEntity : filters) {
-			filteredResults.addAll(getFilteredResults(filtersEntity, userId, newStartId));
+			if (!filtersEntity.getSubreddit().isEmpty()) {
+				if (subreddits.length() != 0) {
+					subreddits.append("+");
+				}
+				subreddits.append(filtersEntity.getSubreddit());
+			}
 		}
 
-		List<ResultsEntity> filteredResultsWithoutDuplicates = new ArrayList<>(new HashSet<>(filteredResults));
-		Collections.sort(filteredResultsWithoutDuplicates, new SortResultsById());
-		
-		ResultsResponseModel results = new ResultsResponseModel();
-		Type listType = new TypeToken<List<ResultsObjectResponseModel>>() {
-		}.getType();
-		List<ResultsObjectResponseModel> responseObject = new ModelMapper().map(filteredResultsWithoutDuplicates, listType);
-		results.setResults(responseObject);
-		results.setNextUri(nextUri);
-		results.setAfterId(nextAfterId);
-		
-		return results;
-	}
-
-	private List<ResultsEntity> getFilteredResults(FiltersEntity filtersEntity, String userId, Long startId) {
-		return resultsRepository.findAll(
-						Specification.where(ResultsSpecification.withUserId(userId))
-						.and(ResultsSpecification.withStartId(startId))
-						.and(ResultsSpecification.withSubreddit(filtersEntity.getSubreddit())
-						.and(ResultsSpecification.withMinScore(filtersEntity.getMinScore()))
-						.and(ResultsSpecification.withNSFW(filtersEntity.getAllowNSFWFlag()))
-						.and(ResultsSpecification.withDomainOnly(setYoutubeFilterIfYoutube(filtersEntity.getShowByDomain())))
-						.and(ResultsSpecification.withoutDomain(setYoutubeFilterIfYoutube(filtersEntity.getHideByDomain())))
-						.and(ResultsSpecification.withTitleKeyword(filtersEntity.getShowByKeyword()))
-						.and(ResultsSpecification.withoutTitleKeyword(filtersEntity.getHideByKeyword()))));
-	}
-
-	private String setYoutubeFilterIfYoutube (String domain) {
-		String youtubeFilter = "youtu";
-		if (domain.toLowerCase().contains(youtubeFilter)) {
-			return youtubeFilter;
-		} else {
-			return domain;
+		String limit = "limit=100";
+		StringBuilder uri = new StringBuilder("/");
+		if (subreddits.length() != 0) {
+			uri.append("r/").append(subreddits).append("/").append(orderBy).append("/?").append(limit);
 		}
+
+		return uri.toString();
 	}
 
-	private ResultsFetchResponseModel sendGetResultsRequest(UserDTO user, String baseUrl, String uri) {
+	private ResultsFetchResponseModel sendGetResultsRequest(UserDTO user, String uri) {
 		String token = user.getToken();
 		if (token == null || token.isEmpty()) {
 			throw new RedditAccountNotAuthenticatedException(ErrorPrefixes.RESULTS_SERVICE.getErrorPrefix()
 					+ ErrorMessages.REDDIT_ACCOUNT_NOT_AUTHENTICATED.getErrorMessage());
 		}
 
-		String userAgentHeader = "web:ca.tunestumbler.api:v0.0.1 (by /u/CrispiestHashbrown)";
+		String userAgentHeader = "web:ca.tunestumbler.api:v1.0.0 (by /u/CrispiestHashbrown)";
 		String authHeader = SecurityConstants.TOKEN_PREFIX + token;
+		String baseUrl = "https://oauth.reddit.com";
 
 		WebClient client = WebClient.builder().baseUrl(baseUrl).defaultHeader(HttpHeaders.USER_AGENT, userAgentHeader)
 				.defaultHeader(HttpHeaders.AUTHORIZATION, authHeader)
@@ -202,78 +151,84 @@ public class ResultsServiceImpl implements ResultsService {
 		WebClient.UriSpec<WebClient.RequestBodySpec> request = client.method(HttpMethod.GET);
 		WebClient.RequestBodySpec requestUri = request.uri(uri);
 
-		return requestUri
-						.exchange()
-						.map(clientResponse -> {
-							if (clientResponse.statusCode().equals(HttpStatus.TOO_MANY_REQUESTS)) {
-								throw new TooManyRequestsFailedException(ErrorPrefixes.RESULTS_SERVICE.getErrorPrefix()
-										+ ErrorMessages.TOO_MANY_REDDIT_REQUESTS.getErrorMessage() 
-										+ clientResponse.headers().header("x-ratelimit-reset") + " seconds");
-							} else if (clientResponse.statusCode().isError()) {
-								throw new WebRequestFailedException(ErrorPrefixes.RESULTS_SERVICE.getErrorPrefix()
-										+ ErrorMessages.FAILED_EXTERNAL_WEB_REQUEST.getErrorMessage());
-							}
-
-							return clientResponse;
-					    })
-						.block()
-						.bodyToMono(ResultsFetchResponseModel.class)
-						.block();
-	}
-
-	private String filtersURIBuilder(List<FiltersEntity> filters, String orderBy) {
-		StringBuilder subreddits = new StringBuilder("");
-		for (FiltersEntity filtersEntity : filters) {
-			String subreddit = filtersEntity.getSubreddit();
-			if (!subreddit.isEmpty()) {
-				if (subreddits.length() != 0) {
-					subreddits.append("+");
-				}
-				subreddits.append(subreddit);
+		return requestUri.exchange().map(clientResponse -> {
+			if (clientResponse.statusCode().equals(HttpStatus.UNAUTHORIZED)) {
+				throw new RedditAccountNotAuthenticatedException(ErrorPrefixes.RESULTS_SERVICE.getErrorPrefix()
+						+ ErrorMessages.REDDIT_ACCOUNT_NOT_AUTHENTICATED.getErrorMessage());
+			} else if (clientResponse.statusCode().equals(HttpStatus.TOO_MANY_REQUESTS)) {
+				throw new TooManyRequestsFailedException(ErrorPrefixes.RESULTS_SERVICE.getErrorPrefix()
+						+ ErrorMessages.TOO_MANY_REDDIT_REQUESTS.getErrorMessage()
+						+ clientResponse.headers().header("x-ratelimit-reset") + " seconds");
+			} else if (clientResponse.statusCode().isError()) {
+				throw new WebRequestFailedException(ErrorPrefixes.RESULTS_SERVICE.getErrorPrefix()
+						+ ErrorMessages.FAILED_EXTERNAL_WEB_REQUEST.getErrorMessage());
 			}
-		}
 
-		String limit = "limit=60";
-		StringBuilder uri = new StringBuilder("/");
-		if (subreddits.length() != 0) {
-			uri.append("r/").append(subreddits)
-				.append("/").append(orderBy)
-				.append("/?")
-				.append(limit);
-		}
-
-		return uri.toString();
-	}
-
-	private ResultsEntity addResultsEntity(UserEntity userEntity, ResultsDataChildrenDataModel data, long startId) {
-		ResultsEntity resultsEntity = new ResultsEntity();
-		String resultsId = sharedUtils.generateResultsId(idLength);
-		String userId = userEntity.getUserId();
-
-		resultsEntity.setResultsId(resultsId);
-		resultsEntity.setUserId(userId);
-		resultsEntity.setSubreddit(data.getSubreddit());
-		resultsEntity.setTitle(data.getTitle());
-		resultsEntity.setScore(data.getScore());
-		resultsEntity.setCreated(data.getCreated());
-		resultsEntity.setCreatedUtc(data.getCreated_utc());
-		resultsEntity.setDomain(data.getDomain());
-		resultsEntity.setIsNsfw(data.getOver_18());
-		resultsEntity.setIsSpoiler(data.getSpoiler());
-		resultsEntity.setComments(data.getNum_comments());
-		resultsEntity.setPermalink(data.getPermalink());
-		resultsEntity.setIsStickied(data.getStickied());
-		resultsEntity.setUrl(data.getUrl());
-		resultsEntity.setStartId(startId);
-		resultsEntity.setLastModified(sharedUtils.getCurrentTime());
-
-		return resultsEntity;
+			return clientResponse;
+		}).block().bodyToMono(ResultsFetchResponseModel.class).block();
 	}
 
 	private Long setResultsStartId(String userId) {
 		Long userMaxId = resultsRepository.findMaxIdByUserId(userId);
 		Long maxId = resultsRepository.findMaxId();
 		return sharedUtils.setStartId(userMaxId, maxId);
+	}
+
+	private List<ResultsObjectResponseModel> buildFilteredResultObjects(List<FiltersEntity> filters, long maxId) {
+		List<ResultsEntity> filteredResultEntities = getFilteredResults(filters, maxId);
+		List<ResultsDTO> filteredResultDTOs = resultsMapper.resultsEntityListToResultsDTOlist(filteredResultEntities);
+		return resultsMapper.resultsDTOlistToResultsResponseObjectList(filteredResultDTOs);
+	}
+
+	private List<ResultsEntity> getFilteredResults(List<FiltersEntity> filters, Long startId) {
+		List<ResultsEntity> filteredResults = new ArrayList<>();
+		for (FiltersEntity filter : filters) {
+			ResultsSpecification resultsSpec = new ResultsSpecification();
+			createCommonResultsSpecification(filter, startId, resultsSpec);
+			createDomainFilterResultsSpecification(filter, resultsSpec);
+			filteredResults.addAll(resultsRepository.findAll(resultsSpec));
+		}
+
+		Collections.sort(filteredResults, new SortResultsById());
+		return filteredResults;
+	}
+
+	private void createCommonResultsSpecification(FiltersEntity filter, Long startId,
+			ResultsSpecification resultsSpec) {
+		resultsSpec.add(new SearchCriteria(filter.getUserId(), "userId", SearchOperation.EQUAL));
+		resultsSpec.add(new SearchCriteria(startId, "startId", SearchOperation.GREATER_THAN_OR_EQUAL));
+		resultsSpec.add(new SearchCriteria(filter.getSubreddit(), "subreddit", SearchOperation.EQUAL));
+		resultsSpec.add(new SearchCriteria(filter.getMinScore(), "score", SearchOperation.GREATER_THAN_OR_EQUAL));
+		resultsSpec.add(new SearchCriteria(filter.getAllowNSFWFlag(), "isNsfw", SearchOperation.EQUAL));
+		for (ExcludedKeywordEntity excludedKeyword : filter.getExcludedKeywords()) {
+			resultsSpec
+					.add(new SearchCriteria(excludedKeyword.getExcludedKeyword(), "keyword", SearchOperation.NOT_LIKE));
+		}
+		for (SelectedKeywordEntity selectedKeyword : filter.getSelectedKeywords()) {
+			resultsSpec.add(new SearchCriteria(selectedKeyword.getSelectedKeyword(), "keyword", SearchOperation.LIKE));
+		}
+	}
+
+	private void createDomainFilterResultsSpecification(FiltersEntity filter, ResultsSpecification resultsSpec) {
+		for (ExcludedDomainEntity excludedDomain : filter.getExcludedDomains()) {
+			resultsSpec.add(new SearchCriteria(setYoutubeFilterIfYoutubeDomain(excludedDomain.getExcludedDomain()),
+					"domain", SearchOperation.NOT_LIKE));
+		}
+		for (SelectedDomainEntity selectedDomain : filter.getSelectedDomains()) {
+			resultsSpec.add(new SearchCriteria(setYoutubeFilterIfYoutubeDomain(selectedDomain.getSelectedDomain()),
+					"domain", SearchOperation.LIKE));
+		}
+	}
+
+	private String setYoutubeFilterIfYoutubeDomain(String domain) {
+		String youtubeDomain = "youtube.com";
+		String youtubeShortDomain = "youtu.be";
+		String youtubeFilter = "youtu";
+		if (domain.toLowerCase().contains(youtubeDomain) || domain.toLowerCase().contains(youtubeShortDomain)) {
+			return youtubeFilter;
+		} else {
+			return domain;
+		}
 	}
 
 }

--- a/src/main/java/ca/tunestumbler/api/shared/dto/NextResultsRequestDTO.java
+++ b/src/main/java/ca/tunestumbler/api/shared/dto/NextResultsRequestDTO.java
@@ -1,0 +1,23 @@
+package ca.tunestumbler.api.shared.dto;
+
+public class NextResultsRequestDTO {
+	private String afterId;
+	private String nextUri;
+
+	public String getAfterId() {
+		return afterId;
+	}
+
+	public void setAfterId(String afterId) {
+		this.afterId = afterId;
+	}
+
+	public String getNextUri() {
+		return nextUri;
+	}
+
+	public void setNextUri(String nextUri) {
+		this.nextUri = nextUri;
+	}
+
+}

--- a/src/main/java/ca/tunestumbler/api/shared/dto/ResultsDTO.java
+++ b/src/main/java/ca/tunestumbler/api/shared/dto/ResultsDTO.java
@@ -1,74 +1,19 @@
-package ca.tunestumbler.api.io.entity;
+package ca.tunestumbler.api.shared.dto;
 
-import java.io.Serializable;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-
-@Entity(name = "results")
-public class ResultsEntity implements Serializable {
-	private static final long serialVersionUID = -8505575230126284466L;
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(nullable = false, unique = true)
-	private long id;
-
-	@Column(nullable = false, unique = true)
+public class ResultsDTO {
 	private String resultsId;
-
-	@Column()
-	private String userId;
-
-	@Column(nullable = false, length = 21)
 	private String subreddit;
-
-	@Column(nullable = false, length = 500)
 	private String title;
-
-	@Column(nullable = false)
 	private int score;
-
-	@Column(nullable = false)
 	private long created;
-
-	@Column(nullable = false)
 	private long createdUtc;
-
-	@Column(nullable = false)
 	private String domain;
-
-	@Column(nullable = false)
 	private Boolean isNsfw;
-
-	@Column(nullable = false)
 	private Boolean isSpoiler;
-
-	@Column(nullable = false)
 	private int comments;
-	
-	@Column(nullable = false)
 	private String permalink;
-
-	@Column(nullable = false)
 	private Boolean isStickied;
-
-	@Column(nullable = false)
 	private String url;
-
-	@Column()
-	private Long startId;
-
-	public long getId() {
-		return id;
-	}
-
-	public void setId(long id) {
-		this.id = id;
-	}
 
 	public String getResultsId() {
 		return resultsId;
@@ -76,14 +21,6 @@ public class ResultsEntity implements Serializable {
 
 	public void setResultsId(String resultsId) {
 		this.resultsId = resultsId;
-	}
-
-	public String getUserId() {
-		return userId;
-	}
-
-	public void setUserId(String userId) {
-		this.userId = userId;
 	}
 
 	public String getSubreddit() {
@@ -180,14 +117,6 @@ public class ResultsEntity implements Serializable {
 
 	public void setUrl(String url) {
 		this.url = url;
-	}
-
-	public Long getStartId() {
-		return startId;
-	}
-
-	public void setStartId(Long startId) {
-		this.startId = startId;
 	}
 
 }

--- a/src/main/java/ca/tunestumbler/api/shared/mapper/ResultsMapper.java
+++ b/src/main/java/ca/tunestumbler/api/shared/mapper/ResultsMapper.java
@@ -1,0 +1,36 @@
+package ca.tunestumbler.api.shared.mapper;
+
+import java.util.List;
+
+import ca.tunestumbler.api.io.entity.ResultsEntity;
+import ca.tunestumbler.api.shared.dto.NextResultsRequestDTO;
+import ca.tunestumbler.api.shared.dto.ResultsDTO;
+import ca.tunestumbler.api.ui.model.request.NextResultsRequestModel;
+import ca.tunestumbler.api.ui.model.response.ResultsResponseModel;
+import ca.tunestumbler.api.ui.model.response.results.ResultsDataChildrenDataModel;
+import ca.tunestumbler.api.ui.model.response.results.ResultsDataChildrenModel;
+import ca.tunestumbler.api.ui.model.response.results.ResultsObjectResponseModel;
+
+public interface ResultsMapper {
+
+	ResultsDTO resultDataToFiltersDTO(ResultsDataChildrenDataModel resultData);
+
+	NextResultsRequestDTO nextResultsRequestToDTO(NextResultsRequestModel request);
+
+	ResultsEntity resultsDTOtoResultsEntity(ResultsDTO dto, String userId, long startId);
+
+	ResultsDTO resultsEntityToResultsDTO(ResultsEntity entity);
+
+	ResultsObjectResponseModel resultsDTOtoResultsResponseObject(ResultsDTO dto);
+
+	ResultsResponseModel buildResponseModel(List<ResultsObjectResponseModel> responseObjects, String afterId, String uri);
+
+	List<ResultsDTO> resultsDataChildrenListToResultsDTOlist(List<ResultsDataChildrenModel> resultDataList);
+
+	List<ResultsEntity> resultsDTOlistToResultsEntityList(List<ResultsDTO> dtoList, String userId, long startId);
+
+	List<ResultsDTO> resultsEntityListToResultsDTOlist(List<ResultsEntity> entityList);
+
+	List<ResultsObjectResponseModel> resultsDTOlistToResultsResponseObjectList(List<ResultsDTO> dtoList);
+
+}

--- a/src/main/java/ca/tunestumbler/api/shared/mapper/impl/ResultsMapperImpl.java
+++ b/src/main/java/ca/tunestumbler/api/shared/mapper/impl/ResultsMapperImpl.java
@@ -1,0 +1,209 @@
+package ca.tunestumbler.api.shared.mapper.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import ca.tunestumbler.api.io.entity.ResultsEntity;
+import ca.tunestumbler.api.shared.SharedUtils;
+import ca.tunestumbler.api.shared.dto.NextResultsRequestDTO;
+import ca.tunestumbler.api.shared.dto.ResultsDTO;
+import ca.tunestumbler.api.shared.mapper.ResultsMapper;
+import ca.tunestumbler.api.ui.model.request.NextResultsRequestModel;
+import ca.tunestumbler.api.ui.model.response.ResultsResponseModel;
+import ca.tunestumbler.api.ui.model.response.results.ResultsDataChildrenDataModel;
+import ca.tunestumbler.api.ui.model.response.results.ResultsDataChildrenModel;
+import ca.tunestumbler.api.ui.model.response.results.ResultsObjectResponseModel;
+
+@Component
+public class ResultsMapperImpl implements ResultsMapper {
+
+	private int length = 50;
+
+	@Autowired
+	SharedUtils sharedUtils;
+
+	@Override
+	public ResultsDTO resultDataToFiltersDTO(ResultsDataChildrenDataModel resultData) {
+		if (resultData == null) {
+			return null;
+		}
+
+		ResultsDTO dto = new ResultsDTO();
+
+		dto.setSubreddit(resultData.getSubreddit());
+		dto.setTitle(resultData.getTitle());
+		dto.setScore(resultData.getScore());
+		dto.setCreated(resultData.getCreated());
+		dto.setCreatedUtc(resultData.getCreated_utc());
+		dto.setDomain(resultData.getDomain());
+		dto.setIsNsfw(resultData.getOver_18());
+		dto.setIsSpoiler(resultData.getSpoiler());
+		dto.setComments(resultData.getNum_comments());
+		dto.setPermalink(resultData.getPermalink());
+		dto.setIsStickied(resultData.getStickied());
+		dto.setUrl(resultData.getUrl());
+
+		return dto;
+	}
+
+	@Override
+	public NextResultsRequestDTO nextResultsRequestToDTO(NextResultsRequestModel request) {
+		if (request == null) {
+			return null;
+		}
+
+		NextResultsRequestDTO dto = new NextResultsRequestDTO();
+
+		dto.setAfterId(request.getAfterId());
+		dto.setNextUri(request.getNextUri());
+
+		return dto;
+	}
+
+	@Override
+	public ResultsEntity resultsDTOtoResultsEntity(ResultsDTO dto, String userId, long startId) {
+		if (dto == null) {
+			return null;
+		}
+
+		ResultsEntity entity = new ResultsEntity();
+
+		entity.setResultsId(sharedUtils.generateResultsId(length));
+		entity.setUserId(userId);
+		entity.setSubreddit(dto.getSubreddit());
+		entity.setTitle(dto.getTitle());
+		entity.setScore(dto.getScore());
+		entity.setCreated(dto.getCreated());
+		entity.setCreatedUtc(dto.getCreatedUtc());
+		entity.setDomain(dto.getDomain());
+		entity.setIsNsfw(dto.getIsNsfw());
+		entity.setIsSpoiler(dto.getIsSpoiler());
+		entity.setComments(dto.getComments());
+		entity.setPermalink(dto.getPermalink());
+		entity.setIsStickied(dto.getIsStickied());
+		entity.setUrl(dto.getUrl());
+		entity.setStartId(startId);
+
+		return entity;
+	}
+
+	@Override
+	public ResultsDTO resultsEntityToResultsDTO(ResultsEntity entity) {
+		if (entity == null) {
+			return null;
+		}
+
+		ResultsDTO dto = new ResultsDTO();
+
+		dto.setResultsId(entity.getResultsId());
+		dto.setSubreddit(entity.getSubreddit());
+		dto.setTitle(entity.getTitle());
+		dto.setScore(entity.getScore());
+		dto.setCreated(entity.getCreated());
+		dto.setCreatedUtc(entity.getCreatedUtc());
+		dto.setDomain(entity.getDomain());
+		dto.setIsNsfw(entity.getIsNsfw());
+		dto.setIsSpoiler(entity.getIsSpoiler());
+		dto.setComments(entity.getComments());
+		dto.setPermalink(entity.getPermalink());
+		dto.setIsStickied(entity.getIsStickied());
+		dto.setUrl(entity.getUrl());
+
+		return dto;
+	}
+
+	@Override
+	public ResultsObjectResponseModel resultsDTOtoResultsResponseObject(ResultsDTO dto) {
+		if (dto == null) {
+			return null;
+		}
+
+		ResultsObjectResponseModel resultsObjectResponseModel = new ResultsObjectResponseModel();
+
+		resultsObjectResponseModel.setResultsId(dto.getResultsId());
+		resultsObjectResponseModel.setSubreddit(dto.getSubreddit());
+		resultsObjectResponseModel.setTitle(dto.getTitle());
+		resultsObjectResponseModel.setScore(dto.getScore());
+		resultsObjectResponseModel.setCreated(dto.getCreated());
+		resultsObjectResponseModel.setCreatedUtc(dto.getCreatedUtc());
+		resultsObjectResponseModel.setDomain(dto.getDomain());
+		resultsObjectResponseModel.setIsNsfw(dto.getIsNsfw());
+		resultsObjectResponseModel.setIsSpoiler(dto.getIsSpoiler());
+		resultsObjectResponseModel.setComments(dto.getComments());
+		resultsObjectResponseModel.setPermalink(dto.getPermalink());
+		resultsObjectResponseModel.setIsStickied(dto.getIsStickied());
+		resultsObjectResponseModel.setUrl(dto.getUrl());
+
+		return resultsObjectResponseModel;
+	}
+
+	@Override
+	public ResultsResponseModel buildResponseModel(List<ResultsObjectResponseModel> responseObjects, String afterId, String uri) {
+		if (responseObjects == null || responseObjects.isEmpty()) {
+			return new ResultsResponseModel();
+		}
+
+		ResultsResponseModel responseModel = new ResultsResponseModel();
+		responseModel.setResults(responseObjects);
+		responseModel.setAfterId(afterId);
+		responseModel.setNextUri(uri);
+
+		return responseModel;
+	}
+
+	@Override
+	public List<ResultsDTO> resultsDataChildrenListToResultsDTOlist(List<ResultsDataChildrenModel> resultDataList) {
+		if (resultDataList == null || resultDataList.isEmpty()) {
+			return new ArrayList<>();
+		}
+		List<ResultsDTO> list = new ArrayList<>(resultDataList.size());
+		for (ResultsDataChildrenModel resultData : resultDataList) {
+			list.add(resultDataToFiltersDTO(resultData.getData()));
+		}
+
+		return list;
+	}
+
+	@Override
+	public List<ResultsEntity> resultsDTOlistToResultsEntityList(List<ResultsDTO> dtoList, String userId, long startId) {
+		if (dtoList == null || dtoList.isEmpty()) {
+			return new ArrayList<>();
+		}
+		List<ResultsEntity> list = new ArrayList<>(dtoList.size());
+		for (ResultsDTO dto : dtoList) {
+			list.add(resultsDTOtoResultsEntity(dto, userId, startId));
+		}
+
+		return list;
+	}
+
+	@Override
+	public List<ResultsDTO> resultsEntityListToResultsDTOlist(List<ResultsEntity> entityList) {
+		if (entityList == null || entityList.isEmpty()) {
+			return new ArrayList<>();
+		}
+		List<ResultsDTO> list = new ArrayList<>(entityList.size());
+		for (ResultsEntity entity : entityList) {
+			list.add(resultsEntityToResultsDTO(entity));
+		}
+
+		return list;
+	}
+
+	@Override
+	public List<ResultsObjectResponseModel> resultsDTOlistToResultsResponseObjectList(List<ResultsDTO> dtoList) {
+		if (dtoList == null || dtoList.isEmpty()) {
+			return new ArrayList<>();
+		}
+		List<ResultsObjectResponseModel> list = new ArrayList<>(dtoList.size());
+		for (ResultsDTO dto : dtoList) {
+			list.add(resultsDTOtoResultsResponseObject(dto));
+		}
+
+		return list;
+	}
+
+}

--- a/src/main/java/ca/tunestumbler/api/ui/model/request/NextResultsRequestModel.java
+++ b/src/main/java/ca/tunestumbler/api/ui/model/request/NextResultsRequestModel.java
@@ -1,15 +1,12 @@
 package ca.tunestumbler.api.ui.model.request;
 
 import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
 
-public class ResultsRequestModel {
+public class NextResultsRequestModel {
 
-	@NotNull(message = "Next uri cannot be null")
 	@NotEmpty(message = "Next uri cannot be empty")
 	private String nextUri;
 
-	@NotNull(message = "AfterId cannot be null")
 	@NotEmpty(message = "AfterId cannot be empty")
 	private String afterId;
 


### PR DESCRIPTION
- The Results Service needs to be refactored/reworked (1) because the
functionality of the monolithic service methods need to be broken up
into smaller and manageable separate private service methods and
(2) because the filter table data was normalized and so filtering the
Reddit search results needs to be changed accordingly.

- Renamed exception handler for
`RedditAccountNotAuthenticatedException`
- Removed `lastModified` property from `ResultsEntity`. Due to reddit
 search results changing quite frequently, there is little reason to
keep record of result timestamps
- Reworked `ResultsSpecification` into a class and a `SearchCriteria`
 model that has a more general usage, where instead of being results
field specific, it creates predicates based on the search operation
and also based on the query field and filter value of each search
criteria. This way, `ResultsSpecification` class is more flexible
- Created `NextResultsRequestDTO` to decouple the `nextUri` and
`nextAfterId` `fetchNextResults` parameters between the control
layer and the service layer
- Refactored the results service methods into separate methods to
divide up the functionality, increase maintainability, and increase
readability
- Created a DTO for results objects to decouple the data between the
results controller and results service
- Created mapper class and methods to do mappings between Reddit
result request responses, DTOs, entities
- Increased result limit header parameter from 60 to 100 so that it
is easier to return filtered Youtube results to the planned
tunestumbler extension
- Added an if block to catch `401 UNAUTHORIZED` Reddit search errors
when requesting results from the Reddit search API
- Implemented a separate method that creates Results specifications:
one for implementing common specifications to both the tunestumbler
website and chrome extension, one for implementing domain
specification just for the tunestumbler website
- Moved `SortResultsById` util class to `repositories.specification`
package because it will only be used in tandem with results
specification class methods
- Removed `userId` specific endpoints, since these are not used