### PR TITLE
Fixed keyword specification

### DIFF
--- a/src/main/java/ca/tunestumbler/api/service/impl/ResultsServiceImpl.java
+++ b/src/main/java/ca/tunestumbler/api/service/impl/ResultsServiceImpl.java
@@ -202,10 +202,10 @@ public class ResultsServiceImpl implements ResultsService {
 		resultsSpec.add(new SearchCriteria(filter.getAllowNSFWFlag(), "isNsfw", SearchOperation.EQUAL));
 		for (ExcludedKeywordEntity excludedKeyword : filter.getExcludedKeywords()) {
 			resultsSpec
-					.add(new SearchCriteria(excludedKeyword.getExcludedKeyword(), "keyword", SearchOperation.NOT_LIKE));
+					.add(new SearchCriteria(excludedKeyword.getExcludedKeyword(), "title", SearchOperation.NOT_LIKE));
 		}
 		for (SelectedKeywordEntity selectedKeyword : filter.getSelectedKeywords()) {
-			resultsSpec.add(new SearchCriteria(selectedKeyword.getSelectedKeyword(), "keyword", SearchOperation.LIKE));
+			resultsSpec.add(new SearchCriteria(selectedKeyword.getSelectedKeyword(), "title", SearchOperation.LIKE));
 		}
 	}
 


### PR DESCRIPTION
Fixed keyword specification not working by renaming query `keyword` to `title`, as per `ResultsEntity` property