### PR TITLE
Created new playlist generation endpoint and refactored Results methods

### DIFF
--- a/src/main/java/ca/tunestumbler/api/exceptions/ApplicationExceptionsHandler.java
+++ b/src/main/java/ca/tunestumbler/api/exceptions/ApplicationExceptionsHandler.java
@@ -19,7 +19,7 @@ public class ApplicationExceptionsHandler {
 
 	@Autowired
 	SharedUtils sharedUtils;
-	
+
 	@ExceptionHandler(value = { MissingPathParametersException.class })
 	public ResponseEntity<Object> handleMissingPathParameterException(MissingPathParametersException exception,
 			WebRequest request) {
@@ -129,6 +129,19 @@ public class ApplicationExceptionsHandler {
 		ErrorObject errorObject = new ErrorObject(
 				httpStatus.toString(),
 				"NO FILTERS FOUND",
+				exception.getMessage(),
+				sharedUtils.getCurrentTime());
+
+		return new ResponseEntity<>(createErrorsResponse(errorObject), httpStatus);
+	}
+
+	@ExceptionHandler(value = { NoResultsFoundForNonexistingSubredditException.class })
+	public ResponseEntity<Object> handleNoResultsFoundForNonexistingSubredditException(
+			NoResultsFoundForNonexistingSubredditException exception, WebRequest request) {
+		HttpStatus httpStatus = HttpStatus.NOT_FOUND;
+		ErrorObject errorObject = new ErrorObject(
+				httpStatus.toString(),
+				"NO RESULTS FOUND. SUBREDDIT(S) MAY NOT EXIST",
 				exception.getMessage(),
 				sharedUtils.getCurrentTime());
 

--- a/src/main/java/ca/tunestumbler/api/exceptions/NoResultsFoundForNonexistingSubredditException.java
+++ b/src/main/java/ca/tunestumbler/api/exceptions/NoResultsFoundForNonexistingSubredditException.java
@@ -1,0 +1,22 @@
+package ca.tunestumbler.api.exceptions;
+
+public class NoResultsFoundForNonexistingSubredditException extends RuntimeException {
+	private static final long serialVersionUID = 6741206555596276312L;
+
+	public NoResultsFoundForNonexistingSubredditException() {
+		super();
+	}
+
+	public NoResultsFoundForNonexistingSubredditException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public NoResultsFoundForNonexistingSubredditException(String message) {
+		super(message);
+	}
+
+	public NoResultsFoundForNonexistingSubredditException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/src/main/java/ca/tunestumbler/api/io/repositories/specification/ResultsSpecification.java
+++ b/src/main/java/ca/tunestumbler/api/io/repositories/specification/ResultsSpecification.java
@@ -15,7 +15,7 @@ import ca.tunestumbler.api.io.entity.ResultsEntity;
 public class ResultsSpecification implements Specification<ResultsEntity> {
 	private static final long serialVersionUID = -244093893557352665L;
 
-	private List<SearchCriteria> list;
+	private transient List<SearchCriteria> list;
 
 	public ResultsSpecification() {
 		this.list = new ArrayList<>();

--- a/src/main/java/ca/tunestumbler/api/service/ResultsService.java
+++ b/src/main/java/ca/tunestumbler/api/service/ResultsService.java
@@ -1,11 +1,15 @@
 package ca.tunestumbler.api.service;
 
+import java.util.List;
+
 import ca.tunestumbler.api.shared.dto.NextResultsRequestDTO;
+import ca.tunestumbler.api.shared.dto.ResultsResponseDTO;
 import ca.tunestumbler.api.shared.dto.UserDTO;
-import ca.tunestumbler.api.ui.model.response.ResultsResponseModel;
 
 public interface ResultsService {
-	ResultsResponseModel fetchResults(UserDTO user, String orderBy);
+	ResultsResponseDTO fetchResults(UserDTO user, String orderBy);
 
-	ResultsResponseModel fetchNextResults(UserDTO user, NextResultsRequestDTO nextResultsRequestDTO);
+	ResultsResponseDTO fetchNextResults(UserDTO user, NextResultsRequestDTO nextResultsRequestDTO);
+
+	List<String> fetchYoutubePlaylists(UserDTO user);
 }

--- a/src/main/java/ca/tunestumbler/api/shared/dto/ResultsResponseDTO.java
+++ b/src/main/java/ca/tunestumbler/api/shared/dto/ResultsResponseDTO.java
@@ -1,0 +1,34 @@
+package ca.tunestumbler.api.shared.dto;
+
+import java.util.List;
+
+public class ResultsResponseDTO {
+	private List<ResultsDTO> results;
+	private String nextUri;
+	private String afterId;
+
+	public List<ResultsDTO> getResults() {
+		return results;
+	}
+
+	public void setResults(List<ResultsDTO> results) {
+		this.results = results;
+	}
+
+	public String getNextUri() {
+		return nextUri;
+	}
+
+	public void setNextUri(String nextUri) {
+		this.nextUri = nextUri;
+	}
+
+	public String getAfterId() {
+		return afterId;
+	}
+
+	public void setAfterId(String afterId) {
+		this.afterId = afterId;
+	}
+
+}

--- a/src/main/java/ca/tunestumbler/api/shared/mapper/ResultsMapper.java
+++ b/src/main/java/ca/tunestumbler/api/shared/mapper/ResultsMapper.java
@@ -5,6 +5,7 @@ import java.util.List;
 import ca.tunestumbler.api.io.entity.ResultsEntity;
 import ca.tunestumbler.api.shared.dto.NextResultsRequestDTO;
 import ca.tunestumbler.api.shared.dto.ResultsDTO;
+import ca.tunestumbler.api.shared.dto.ResultsResponseDTO;
 import ca.tunestumbler.api.ui.model.request.NextResultsRequestModel;
 import ca.tunestumbler.api.ui.model.response.ResultsResponseModel;
 import ca.tunestumbler.api.ui.model.response.results.ResultsDataChildrenDataModel;
@@ -23,8 +24,6 @@ public interface ResultsMapper {
 
 	ResultsObjectResponseModel resultsDTOtoResultsResponseObject(ResultsDTO dto);
 
-	ResultsResponseModel buildResponseModel(List<ResultsObjectResponseModel> responseObjects, String afterId, String uri);
-
 	List<ResultsDTO> resultsDataChildrenListToResultsDTOlist(List<ResultsDataChildrenModel> resultDataList);
 
 	List<ResultsEntity> resultsDTOlistToResultsEntityList(List<ResultsDTO> dtoList, String userId, long startId);
@@ -32,5 +31,9 @@ public interface ResultsMapper {
 	List<ResultsDTO> resultsEntityListToResultsDTOlist(List<ResultsEntity> entityList);
 
 	List<ResultsObjectResponseModel> resultsDTOlistToResultsResponseObjectList(List<ResultsDTO> dtoList);
+
+	ResultsResponseDTO resultsDTOlistToResultsResponseDTO(List<ResultsDTO> dtoList, String afterId, String uri);
+
+	ResultsResponseModel resultsReponseDTOtoResultsResponseModel(ResultsResponseDTO dto);
 
 }

--- a/src/main/java/ca/tunestumbler/api/shared/mapper/impl/ResultsMapperImpl.java
+++ b/src/main/java/ca/tunestumbler/api/shared/mapper/impl/ResultsMapperImpl.java
@@ -10,6 +10,7 @@ import ca.tunestumbler.api.io.entity.ResultsEntity;
 import ca.tunestumbler.api.shared.SharedUtils;
 import ca.tunestumbler.api.shared.dto.NextResultsRequestDTO;
 import ca.tunestumbler.api.shared.dto.ResultsDTO;
+import ca.tunestumbler.api.shared.dto.ResultsResponseDTO;
 import ca.tunestumbler.api.shared.mapper.ResultsMapper;
 import ca.tunestumbler.api.ui.model.request.NextResultsRequestModel;
 import ca.tunestumbler.api.ui.model.response.ResultsResponseModel;
@@ -141,20 +142,6 @@ public class ResultsMapperImpl implements ResultsMapper {
 	}
 
 	@Override
-	public ResultsResponseModel buildResponseModel(List<ResultsObjectResponseModel> responseObjects, String afterId, String uri) {
-		if (responseObjects == null || responseObjects.isEmpty()) {
-			return new ResultsResponseModel();
-		}
-
-		ResultsResponseModel responseModel = new ResultsResponseModel();
-		responseModel.setResults(responseObjects);
-		responseModel.setAfterId(afterId);
-		responseModel.setNextUri(uri);
-
-		return responseModel;
-	}
-
-	@Override
 	public List<ResultsDTO> resultsDataChildrenListToResultsDTOlist(List<ResultsDataChildrenModel> resultDataList) {
 		if (resultDataList == null || resultDataList.isEmpty()) {
 			return new ArrayList<>();
@@ -204,6 +191,34 @@ public class ResultsMapperImpl implements ResultsMapper {
 		}
 
 		return list;
+	}
+
+	@Override
+	public ResultsResponseDTO resultsDTOlistToResultsResponseDTO(List<ResultsDTO> dtoList, String afterId, String uri) {
+		if (dtoList == null || dtoList.isEmpty()) {
+			return new ResultsResponseDTO();
+		}
+
+		ResultsResponseDTO dto = new ResultsResponseDTO();
+		dto.setResults(dtoList);
+		dto.setAfterId(afterId);
+		dto.setNextUri(uri);
+
+		return dto;
+	}
+
+	@Override
+	public ResultsResponseModel resultsReponseDTOtoResultsResponseModel(ResultsResponseDTO dto) {
+		if (dto == null) {
+			return null;
+		}
+
+		ResultsResponseModel resultsResponseModel = new ResultsResponseModel();
+		resultsResponseModel.setResults(resultsDTOlistToResultsResponseObjectList(dto.getResults()));
+		resultsResponseModel.setNextUri(dto.getNextUri());
+		resultsResponseModel.setAfterId(dto.getAfterId());
+
+		return resultsResponseModel;
 	}
 
 }

--- a/src/main/java/ca/tunestumbler/api/ui/model/response/ErrorMessages.java
+++ b/src/main/java/ca/tunestumbler/api/ui/model/response/ErrorMessages.java
@@ -1,24 +1,25 @@
 package ca.tunestumbler.api.ui.model.response;
 
 public enum ErrorMessages {
-	MISSING_REQUIRED_PATH_FIELD("Missing required path field."),
-	INVALID_BODY("Invalid body"),
-	REDDIT_ACCOUNT_NOT_AUTHENTICATED("Reddit account not authenticated. Please refresh authentication token"),
-	FAILED_EXTERNAL_WEB_REQUEST("External request has failed. Please try again later"),
-	RECORD_ALREADY_EXISTS("Record already exists"),
-	INTERNAL_SERVER_ERROR("Internal server error"),
-	NO_RECORD_FOUND("Record with provided id is not found"),
-	SUBREDDIT_RESOURCES_NOT_FOUND("Subreddit resources not found"),
-	FILTER_RESOURCES_NOT_FOUND("Filter resources not found"),
-	NO_RESULTS_RETURNED("No results were returned"),
-	AUTHENTICATION_FAILED("Authentication failed"),
-	COULD_NOT_UPDATE_RECORD("Could not update record"),
-	COULD_NOT_DELETE_RECORD("Could not delete record"),
-	EMAIL_ADDRESS_NOT_VERIFIED("Email address could not be verified"),
-	BAD_REQUEST("Bad request"),
-	COULD_NOT_GENERATE_UNIQUE_STATE("Could not generate unique state. Try again"),
+	MISSING_REQUIRED_PATH_FIELD("Missing required path field. "),
+	INVALID_BODY("Invalid body."),
+	REDDIT_ACCOUNT_NOT_AUTHENTICATED("Reddit account not authenticated. Please refresh authentication token. "),
+	FAILED_EXTERNAL_WEB_REQUEST("External request has failed. Please try again later. "),
+	RECORD_ALREADY_EXISTS("Record already exists. "),
+	INTERNAL_SERVER_ERROR("Internal server error. "),
+	NO_RECORD_FOUND("Record with provided id is not found. "),
+	SUBREDDIT_RESOURCES_NOT_FOUND("Subreddit resources not found. "),
+	FILTER_RESOURCES_NOT_FOUND("Filter resources not found. "),
+	NO_SEARCH_REULTS_FOUND_FOR_NON_EXISTING_SUBREDDITS("No search results found for subreddit(s) that may not exist. Try double checking subreddit(s) spelling. "),
+	NO_RESULTS_RETURNED("No results were returned. "),
+	AUTHENTICATION_FAILED("Authentication failed. "),
+	COULD_NOT_UPDATE_RECORD("Could not update record. "),
+	COULD_NOT_DELETE_RECORD("Could not delete record. "),
+	EMAIL_ADDRESS_NOT_VERIFIED("Email address could not be verified. "),
+	BAD_REQUEST("Bad request. "),
+	COULD_NOT_GENERATE_UNIQUE_STATE("Could not generate unique state. Try again. "),
 	TOO_MANY_REDDIT_REQUESTS("Too many requests to the Reddit API have been made. Please try again after: ");
-	
+
 	private String errorMessage;
 
 	ErrorMessages(String errorMessage) {

--- a/src/main/java/ca/tunestumbler/api/ui/model/response/PlaylistResponseModel.java
+++ b/src/main/java/ca/tunestumbler/api/ui/model/response/PlaylistResponseModel.java
@@ -1,0 +1,16 @@
+package ca.tunestumbler.api.ui.model.response;
+
+import java.util.List;
+
+public class PlaylistResponseModel {
+	private List<String> playlists;
+
+	public List<String> getPlaylists() {
+		return playlists;
+	}
+
+	public void setPlaylists(List<String> playlists) {
+		this.playlists = playlists;
+	}
+
+}


### PR DESCRIPTION
- Added new endpoint and service methods to create up to
ten 50-item-long youtube playlists based on filter preferences
- Playlists are not generated using the Youtube API because the
Youtube API does not allow batch updates to playlists. Instead,
unlisted playlist generation will be used. These unlisted playlists
have a size limit of 50 videos, and can be generated by appending
youtube video ids onto
`http://www.youtube.com/watch_videos?video_ids=`
- 10 playlists is the maximum number of playlists that can be
generated. This number was chosen because each playlist will have at
most, 50 youtube videos. Assuming that each video is only 1 minute
long, this means that in total, there will be 500 minutes, or more
than 8.5 hours of playlist music. This is typically enough, since
results are pulled from Reddit’s `hot` results, which are updated
every 24 hours or so. After which, users will typically request a
new set of playlists anyway.
- So there are two possibilities: the end user has 10 or fewer
subreddits in their filters, or they have more than 10 subreddits.
If there are 10 or fewer subreddits, then each result search will
search through one subreddit and each subreddit will have a number
of results equal to:`50 ids * (10 playlists / # of subreddits)`. If
there are more than 10 subreddits to filter from, then the number of
subreddits per result search will be
`Math.ceil(# of subreddits / 50 ids)` and there will be a total of
10 playlists.
- Generally, the flow will be: (1) search for and persist each
subreddit results until there are enough filtered results to fill
the quota of playlists, (2) parse each result url for the youtube id
and convert them to playlist urls with 50 ids each, (3) repeat for
each subreddit/set of subreddits
- Added logic to the `sendGetResultsRequests` to handle `302`
directs and to throw an error if no results are returned from a
potentially non-existent subreddit

- Created new `ResultsReponseDTO`s to separate the
`ResultsResponseModel` from the service layer, and changed service
member return types accordingly
- Refactored service method behaviors into separate smaller private 
service methods so that the playlist generation logic can also reuse
some of the logic of the already existing methods
- Added new exception handler to catch and handle empty responses to
non-existent subreddit search requests. The error response also
returns the url so that the end user can know which filters to
correct
- Made the private `ResultsSpecification` `SearchCriteria` list a
`transient` member since the list is derived from the calling class
creating new specification objects and adding them to the list,
rather than being persisted by serialization