### PR TITLE
Duplicate filtered results and out of bounds error for playlist builder

### DIFF
--- a/src/main/java/ca/tunestumbler/api/service/impl/ResultsServiceImpl.java
+++ b/src/main/java/ca/tunestumbler/api/service/impl/ResultsServiceImpl.java
@@ -217,8 +217,9 @@ public class ResultsServiceImpl implements ResultsService {
 			List<FiltersEntity> filtersGroup, Long startId, int numOfFilteredResultsPerSearch, String uri) {
 		String afterId = response.getData().getAfter();
 		if (getFilteredResultsCount(filtersGroup, startId) < numOfFilteredResultsPerSearch) {
-			for (int idCount = 0; idCount < numOfFilteredResultsPerSearch
-					|| afterId == null; idCount = getFilteredResultsCount(filtersGroup, startId)) {
+			for (int idCount = getFilteredResultsCount(filtersGroup, startId); afterId != null
+					&& idCount < numOfFilteredResultsPerSearch; idCount = getFilteredResultsCount(filtersGroup,
+							startId)) {
 				String nextUri = uri + "&after=" + afterId;
 				ResultsFetchResponseModel nextResponse = sendGetResultsRequest(user, nextUri);
 				if (nextResponse == null) {
@@ -250,9 +251,12 @@ public class ResultsServiceImpl implements ResultsService {
 		playlistUrl.append("https://www.youtube.com/watch_videos?video_ids=");
 		int defaultUrlLength = playlistUrl.length();
 		for (int id = 0; id <= numOfFilteredResultsPerSearch; id++) {
-			if (id > 0 && id % playlistSize == 0) {
+			if (id > 0 && id % playlistSize == 0 || id >= playlistIds.size()) {
 				playlists.add(playlistUrl.toString());
 				playlistUrl.setLength(defaultUrlLength);
+			}
+			if (id >= playlistIds.size()) {
+				break;
 			}
 			playlistUrl.append(playlistIds.get(id) + ",");
 		}


### PR DESCRIPTION
- Bug: there are duplicate ids when fetching and persisting
next results
- This bug occurs because the for loop's execution condition is not
properly defined, as it should only execute when `afterId` is not
`null` and when `idCount` is less than the max number of filtered
results per result search (now fixed)
- The for loop also does not initiate `idCount` at the proper
starting value, since it should also account for the filtered results
from the initial `Results` request (now fixed)
---
- Bug: when iterating to build playlist urls using `id`s, the
iteration goes out of bounds
- This happens on `playlistIds.get(id)` when the `id` index becomes
greater than or equal to `playlistIds.size()`
- The `id` index is able to reach out of bounds because the execution
condition doesn’t break
- Accounting for this in the execution condition is insufficient,
since there is a scenario when the number of `id`s is less than the
`numOfFilteredResultsPerSearch`, and then instead of breaking this
condition, `id` will reach out of bounds
- So the solution is to handle when `id` becomes greater than or
equal to the `playlistIds.size()`, add the current playlist to the
list, and then `break` out of the loop