### PR TITLE
Return generated youtube embed urls

### DIFF
--- a/src/main/java/ca/tunestumbler/api/exceptions/ApplicationExceptionsHandler.java
+++ b/src/main/java/ca/tunestumbler/api/exceptions/ApplicationExceptionsHandler.java
@@ -180,7 +180,7 @@ public class ApplicationExceptionsHandler {
 		ErrorObject errorObject = new ErrorObject(
 				httpStatus.toString(),
 				"INTERNAL EXCEPTION",
-				exception.getMessage(),
+				exception.toString(),
 				sharedUtils.getCurrentTime());
 
 		return new ResponseEntity<>(createErrorsResponse(errorObject), httpStatus);


### PR DESCRIPTION
- Reddit query parameters seems to only allow filtering one domain,
and this means that separate searches needs to be done for
`youtube`.com and `youtu.be`
- In response to this, the service method to generate Youtube
playlists will now make two requests: one for `youtube` and one for
`youtu`, which searches for `youtu.be`
- Also, instead of using
`http://www.youtube.com/watch_videos?video_ids=` to prepend the url,
which has a limitation of 50 videos per playlist, the Url generation
will be using the url format
`https://www.youtube.com/embed/{id}?playlist={ids}&version=3`, which
has no video limitation.
- Playlist count will be lowered to 5 from 10 playlists, which
totals to 10 playlists since there are now two separate searches for
each Youtube domain, and the playlist size will be increased to 100
from 50, so that the number of overall results stays relatively the
same
- Modified createFilterGroupPlaylists to account for the new url
generation
- Added a check to `createFilterGroupPlaylists` to return an empty
array if there are no playlist ids
-----------------
- Changed error message from `exception.getMessage()` to
`exception.toString()` for `handleOtherExceptions`. This is because,
often times, the exception has no `message` field and so returns
`null` instead of useful information, and so I figure sending the
entire exception should be enough, and hopefully doesn’t expose any
sensitive information.