### PR TITLE
Fixed Results Specification Predicate method

### DIFF
--- a/src/main/java/ca/tunestumbler/api/io/repositories/specification/ResultsSpecification.java
+++ b/src/main/java/ca/tunestumbler/api/io/repositories/specification/ResultsSpecification.java
@@ -16,9 +16,13 @@ public class ResultsSpecification implements Specification<ResultsEntity> {
 	private static final long serialVersionUID = -244093893557352665L;
 
 	private transient List<SearchCriteria> list;
+	private transient List<SearchCriteria> likeSelectedDomains;
+	private transient List<SearchCriteria> likeSelectedKeywords;
 
 	public ResultsSpecification() {
 		this.list = new ArrayList<>();
+		this.likeSelectedDomains = new ArrayList<>();
+		this.likeSelectedKeywords = new ArrayList<>();
 	}
 
 	public void add(SearchCriteria criteria) {
@@ -27,9 +31,23 @@ public class ResultsSpecification implements Specification<ResultsEntity> {
 		}
 	}
 
+	public void addLikeSelectedDomains(SearchCriteria criteria) {
+		if (!(criteria.getValue() == null || criteria.getValue().toString().isEmpty())) {
+			this.likeSelectedDomains.add(criteria);
+		}
+	}
+
+	public void addLikeSelectedKeywords(SearchCriteria criteria) {
+		if (!(criteria.getValue() == null || criteria.getValue().toString().isEmpty())) {
+			this.likeSelectedKeywords.add(criteria);
+		}
+	}
+
 	@Override
 	public Predicate toPredicate(Root<ResultsEntity> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder) {
 		List<Predicate> predicates = new ArrayList<>();
+		List<Predicate> selectedDomainPredicates = new ArrayList<>();
+		List<Predicate> selectedKeywordPredicates = new ArrayList<>();
 		for (SearchCriteria criteria : list) {
 			if (criteria.getOperation().equals(SearchOperation.EQUAL)) {
 				if (isString(criteria.getValue())) {
@@ -40,16 +58,33 @@ public class ResultsSpecification implements Specification<ResultsEntity> {
 				}
 			} else if (criteria.getOperation().equals(SearchOperation.GREATER_THAN_OR_EQUAL)) {
 				predicates.add(criteriaBuilder.ge(root.get(criteria.getField()), (Number) criteria.getValue()));
-			} else if (criteria.getOperation().equals(SearchOperation.LIKE)) {
-				predicates.add(criteriaBuilder.like(root.get(criteria.getField()),
-						"%" + criteria.getValue().toString().toLowerCase() + "%"));
 			} else if (criteria.getOperation().equals(SearchOperation.NOT_LIKE)) {
 				predicates.add(criteriaBuilder.notLike(root.get(criteria.getField()),
 						"%" + criteria.getValue().toString().toLowerCase() + "%"));
 			}
 		}
 
-		return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+		if (!likeSelectedDomains.isEmpty()) {
+			for (SearchCriteria criteria : likeSelectedDomains) {
+				selectedDomainPredicates.add(criteriaBuilder.like(root.get(criteria.getField()),
+						"%" + criteria.getValue().toString().toLowerCase() + "%"));
+			}
+		} else {
+			selectedDomainPredicates.add(criteriaBuilder.like(root.get("domain"), "%%"));
+		}
+
+		if (!likeSelectedKeywords.isEmpty()) {
+			for (SearchCriteria criteria : likeSelectedKeywords) {
+				selectedKeywordPredicates.add(criteriaBuilder.like(root.get(criteria.getField()),
+						"%" + criteria.getValue().toString().toLowerCase() + "%"));
+			}
+		} else {
+			selectedKeywordPredicates.add(criteriaBuilder.like(root.get("title"), "%%"));
+		}
+
+		return criteriaBuilder.and(criteriaBuilder.and(predicates.toArray(new Predicate[0])),
+				criteriaBuilder.or(selectedDomainPredicates.toArray(new Predicate[0])),
+				criteriaBuilder.or(selectedKeywordPredicates.toArray(new Predicate[0])));
 	}
 
 	private boolean isString(Object any) {

--- a/src/main/java/ca/tunestumbler/api/service/impl/ResultsServiceImpl.java
+++ b/src/main/java/ca/tunestumbler/api/service/impl/ResultsServiceImpl.java
@@ -292,7 +292,8 @@ public class ResultsServiceImpl implements ResultsService {
 					.add(new SearchCriteria(excludedKeyword.getExcludedKeyword(), "title", SearchOperation.NOT_LIKE));
 		}
 		for (SelectedKeywordEntity selectedKeyword : filter.getSelectedKeywords()) {
-			resultsSpec.add(new SearchCriteria(selectedKeyword.getSelectedKeyword(), "title", SearchOperation.LIKE));
+			resultsSpec.addLikeSelectedKeywords(
+					new SearchCriteria(selectedKeyword.getSelectedKeyword(), "title", SearchOperation.LIKE));
 		}
 
 		return resultsSpec;
@@ -304,8 +305,9 @@ public class ResultsServiceImpl implements ResultsService {
 					"domain", SearchOperation.NOT_LIKE));
 		}
 		for (SelectedDomainEntity selectedDomain : filter.getSelectedDomains()) {
-			resultsSpec.add(new SearchCriteria(setYoutubeFilterIfYoutubeDomain(selectedDomain.getSelectedDomain()),
-					"domain", SearchOperation.LIKE));
+			resultsSpec.addLikeSelectedDomains(
+					new SearchCriteria(setYoutubeFilterIfYoutubeDomain(selectedDomain.getSelectedDomain()), "domain",
+							SearchOperation.LIKE));
 		}
 	}
 


### PR DESCRIPTION
- Bug: The `selected` filters were ‘AND’ing with the other filters,
and this results in no results
- Example: find titles with `%keyword1%` AND `%keyword2%` AND
`%keyword3%` instead of `%keyword1%` OR `%keyword2%` OR
`%keyword3%` 
- Solution 1: build out each predicate individually, which is
inflexible and fragile
- Solution 2: build out predicate by grouping similar criteria for
more efficient queries (`selectedDomains` and `selectedKeywords`)
- Also, to handle whenever selected predicate lists are empty,
a predicate is added to the lists that searches for all string
patterns, using `%%`
- This workaround is used because there is no way to provide a
default value for an empty predicate and there is no way to
dynamically build a `Predicate` using `CriteriaBuilder`
- This workaround works since no results get filtered out
accidentally, and empty filtered results are avoided