### PR TITLE
Added error handler for private subreddit

### DIFF
--- a/src/main/java/ca/tunestumbler/api/service/impl/ResultsServiceImpl.java
+++ b/src/main/java/ca/tunestumbler/api/service/impl/ResultsServiceImpl.java
@@ -335,6 +335,10 @@ public class ResultsServiceImpl implements ResultsService {
 					} else if (clientResponse.statusCode().equals(HttpStatus.UNAUTHORIZED)) {
 						throw new RedditAccountNotAuthenticatedException(ErrorPrefixes.RESULTS_SERVICE.getErrorPrefix()
 								+ ErrorMessages.REDDIT_ACCOUNT_NOT_AUTHENTICATED.getErrorMessage());
+					} else if (clientResponse.statusCode().equals(HttpStatus.FORBIDDEN)) {
+						throw new RedditAccountNotAuthenticatedException(ErrorPrefixes.RESULTS_SERVICE.getErrorPrefix()
+								+ ErrorMessages.SUBREDDIT_HAS_GONE_PRIVATE.getErrorMessage()
+								+ "url: " + baseUrl + uri);
 					} else if (clientResponse.statusCode().equals(HttpStatus.TOO_MANY_REQUESTS)) {
 						throw new TooManyRequestsFailedException(ErrorPrefixes.RESULTS_SERVICE.getErrorPrefix()
 								+ ErrorMessages.TOO_MANY_REDDIT_REQUESTS.getErrorMessage()

--- a/src/main/java/ca/tunestumbler/api/ui/model/response/ErrorMessages.java
+++ b/src/main/java/ca/tunestumbler/api/ui/model/response/ErrorMessages.java
@@ -4,6 +4,7 @@ public enum ErrorMessages {
 	MISSING_REQUIRED_PATH_FIELD("Missing required path field. "),
 	INVALID_BODY("Invalid body."),
 	REDDIT_ACCOUNT_NOT_AUTHENTICATED("Reddit account not authenticated. Please refresh authentication token. "),
+	SUBREDDIT_HAS_GONE_PRIVATE("Subreddit has turned private. Unable to get results. "),
 	FAILED_EXTERNAL_WEB_REQUEST("External request has failed. Please try again later. "),
 	RECORD_ALREADY_EXISTS("Record already exists. "),
 	INTERNAL_SERVER_ERROR("Internal server error. "),


### PR DESCRIPTION
- Since Subreddits can turn their subreddits private (ie: during
a protest), sometimes a `FORBIDDEN` response is returned when trying
to fetch Subreddit results
- So error handling logic has been added to the
`sendGetResultsRequest` and also a custom error message has been
created