### PR TITLE
fixed CORS preflight error – missing Access-Control-Allow-Headers

### DIFF
--- a/src/main/java/ca/tunestumbler/api/WebConfiguration.java
+++ b/src/main/java/ca/tunestumbler/api/WebConfiguration.java
@@ -14,7 +14,7 @@ public class WebConfiguration implements WebMvcConfigurer {
 				.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
 				.allowedOrigins("http://www.tunestumbler.com", "https://www.tunestumbler.com", "https://www.reddit.com")
 				.allowedHeaders("Authorization", "Cache-Control", "Content-Type", "X-Requested-With",
-						"Access-Control-Allow-Headers", "Origin", "Accept", "User-Agent");
+						"Access-Control-Allow-Headers", "Access-Control-Allow-Origin", "Origin", "Accept", "User-Agent");
 	}
 
 }

--- a/src/main/java/ca/tunestumbler/api/security/WebSecurity.java
+++ b/src/main/java/ca/tunestumbler/api/security/WebSecurity.java
@@ -2,6 +2,7 @@ package ca.tunestumbler.api.security;
 
 import java.util.Arrays;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -49,6 +50,7 @@ public class WebSecurity extends WebSecurityConfigurerAdapter {
 		return filter;
 	}
 
+	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		final CorsConfiguration configuration = new CorsConfiguration();
 


### PR DESCRIPTION
- When accessing the API from the frontend website, there is a CORS
preflight error that is caused by missing
`Access-Control-Allow-Headers` header, so to fix this, the header is
added to the list of allowed headers
- Also, I forgot to add the `@Bean` annotation to the
`CorsConfigurationSource` method, which most likely also caused CORS
issues, so adding this method as a Bean seems to have alleviated any
existing CORS issues